### PR TITLE
Reshape repo from reference library to guided course (journey CLI, workbook, "today's session" path)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,11 @@ site_src/
 
 # Node modules (e.g. vscode-extension/)
 node_modules/
+
+# Workbook (learner's private attempts / journal / notes). Keep the
+# top-level README so the directory is documented even when ignored.
+# Use a glob (not a recursive `workbook/`) so the `!workbook/README.md`
+# negation can re-include the docs file — git can't un-exclude inside an
+# excluded directory.
+workbook/*
+!workbook/README.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,10 @@ python scripts/quality_check.py
 
 Must exit `0`. If you've added drift the lint will say so. See **Quality lint** below for what each check does and how to fix the common failure modes.
 
+### Workbook (your personal workspace)
+
+`workbook/` is gitignored. Don't ever PR a workbook attempt to the main repo — those are personal scratchwork. Instead, polished solutions you want to share go in `showcase/submissions/` via a PR.
+
 ### Adding a fixture and reference (for topic files)
 
 If your new file implements an algorithm that has a `tests/cases/<topic>.json` fixture, the test harness will pick it up automatically. If you're adding a brand-new topic that *deserves* a fixture (most algorithmic ones do):

--- a/INDEX.md
+++ b/INDEX.md
@@ -67,10 +67,41 @@ Every doc in this repo, grouped by purpose. Skim it once to know what exists; co
 
 ## 🛠️ Tools
 
-- [`scripts/build_all.sh`](scripts/build_all.sh) — local equivalent of CI smoke test.
-- [`scripts/journey`](scripts/journey) — mastery quiz CLI; `progress` shows dashboard; `progress --html` opens visual dashboard.
-- [`scripts/coverage_report.py`](scripts/coverage_report.py) — regenerates `tests/COVERAGE.md`.
-- [`scripts/ask`](scripts/ask) — AI tutor CLI; ask natural-language questions, get answers retrieved from this repo (offline by default, optional `--llm` mode). See [`docs/AI_TUTOR.md`](docs/AI_TUTOR.md).
+**Daily learning loop (the journey CLI):**
+
+- `./scripts/journey start` — 2-minute onboarding
+- `./scripts/journey next` — next session, time-scaled (`--time 15m | 30m | 1h | weekend`)
+- `./scripts/journey new-attempt <topic>` — create a workbook stub to code in
+- `./scripts/journey verify <topic> <file>` — run YOUR code against the topic's fixtures
+- `./scripts/journey reflect` — append today's reflection prompts to your journal
+- `./scripts/journey quiz N [--review]` — mastery quiz with optional FSRS interleave
+- `./scripts/journey review` — FSRS-due skills across all weeks
+- `./scripts/journey daily` — today's drill + challenge + reflection
+- `./scripts/journey progress --html` — visual dashboard
+
+See [`docs/JOURNEY_CLI.md`](docs/JOURNEY_CLI.md) for examples and the full reference.
+
+**Build / smoke test:**
+
+- `./scripts/build_all.sh [python|cpp|rust|java|all]` — local smoke test (same as CI)
+- `./scripts/build_all.sh next` — passthrough to journey CLI
+
+**Quality + coverage:**
+
+- `python scripts/quality_check.py` — 8-category schema & consistency lint
+- `python scripts/coverage_report.py` — regenerates `tests/COVERAGE.md`
+- `python scripts/build_ask_index.py` — rebuilds the AI tutor's TF-IDF index
+
+**AI tutor:**
+
+- `./scripts/ask "<question>"` — retrieve from repo content (templated response)
+- `./scripts/ask --llm "<question>"` — same, using Anthropic API if `ANTHROPIC_API_KEY` is set
+
+**Site / book / playground:**
+
+- `bash scripts/prepare_site.sh && mkdocs build` — render the static site
+- `bash scripts/build_book.sh` — generate PDF + ePub via pandoc
+- `playground/index.html` — Pyodide-powered browser playground for any python file
 
 ---
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -16,6 +16,7 @@ You will do that loop eight times today.
 2. Copy [`docs/SOLUTION_JOURNAL.md`](docs/SOLUTION_JOURNAL.md) to `my_journal.md` in your working directory (not committed). You will append one entry per problem.
 3. Set a 4-hour timer. If you blow past a budget by more than 5 minutes on any problem, stop, peek at the reference file, and move on. The point today is *coverage of the loop*, not perfect solutions.
 4. Open your scratch editor with two panes: the problem on the left, your journal on the right.
+4. **Optional: skip the manual file-hunting** — `./scripts/journey start && ./scripts/journey next` will tell you exactly which file to open for each of the 8 problems below. The CLI is faster than manually navigating to each file.
 
 > **One rule, non-negotiable.** Attempt every problem *before* opening the reference file. Reading the answer first turns this from training into entertainment.
 

--- a/README.md
+++ b/README.md
@@ -18,20 +18,50 @@ Implementations across **5 tracks** — Java, Python, C++, Rust, and self-contai
 
 ## Start Here
 
-**First time on this repo?** 30 weeks is a real commitment. Before you make it, try one of these two on-ramps:
+**First time on this repo?** Two paths in:
 
-- **[QUICKSTART.md](QUICKSTART.md) — 4 hours, 8 problems.** A focused session that walks you through the full methodology (decompose → recognize a pattern → implement → journal) on representative problems across every difficulty level. If the loop works for you, the long path is just more reps of it.
-- **[docs/diagnostic.md](docs/diagnostic.md) — 15 questions, ~25 minutes.** A calibrated diagnostic that places you into the curriculum so you don't waste weeks relearning what you already know. Maps your score to a specific starting week.
+### Just getting started
 
-Already convinced? Skip ahead to [Learning Paths](#learning-paths) or jump straight to [Week 1](Week%201/).
+```bash
+./scripts/journey start    # 2-minute onboarding: language, time, goal
+./scripts/journey next     # tells you exactly what to do next, takes 15-60 min
+```
+
+That's it. The CLI picks your next session — concept to read, drill to try, code to write, quiz to take. No menu, no choice paralysis. One next thing.
+
+### Want to look first
+
+- **[QUICKSTART.md](QUICKSTART.md) — 4 hours, 8 problems.** A focused session covering the full methodology (decompose → recognize a pattern → implement → journal) across every difficulty level.
+- **[docs/diagnostic.md](docs/diagnostic.md) — 15 questions, ~25 min.** A calibrated placement test that maps your score to a starting week.
+- **[INDEX.md](INDEX.md)** — master index of every file in this repo.
+
+### Already convinced?
+
+Skip to [Learning Paths](#learning-paths) or jump straight to [Week 1](Week%201/).
 
 **Done a capstone?** [Submit it to the showcase →](showcase/README.md)
 
-**Looking for a specific doc?** See [INDEX.md](INDEX.md) — the master index of every file in this repo, grouped by purpose.
+**Multilingual?** Mindset docs in [हिन्दी](translations/hi/), [Español](translations/es/), [中文](translations/zh/). [Want to add yours?](CONTRIBUTING.md#translations)
 
-**🌍 Languages**: English (default) · [हिन्दी](translations/hi/) · [Español](translations/es/) · [中文](translations/zh/) · [Want to add yours?](CONTRIBUTING.md#translations)
+## How the journey CLI works
 
-**🎧 Audio version**: spoken-form transcripts ready for TTS or narration are in [`audio/`](audio/) — see [`audio/README.md`](audio/README.md) to generate them or contribute professional recordings. Video walkthroughs: [`video/`](video/).
+The `./scripts/journey` CLI is the heart of the daily learning loop. Run `./scripts/journey --help` for the full reference, or see [`docs/JOURNEY_CLI.md`](docs/JOURNEY_CLI.md) for examples.
+
+| Command | What it does |
+|---------|--------------|
+| `journey start` | One-time setup: primary language, time per session, goal |
+| `journey next` | The big one — picks your next session based on progress + FSRS due-skills + available time |
+| `journey next --time 15m` | Shorter session (drill only) |
+| `journey next --time weekend` | Capstone-sized scope |
+| `journey new-attempt <topic>` | Creates a stub in `workbook/` for you to code in |
+| `journey verify <topic> <file>` | Runs YOUR code against fixtures — the most empowering single command |
+| `journey reflect` | Appends today's reflection prompts to your week's journal |
+| `journey quiz N` | Mastery quiz for week N (with spaced repetition built in) |
+| `journey review` | Runs only FSRS-due skills across all weeks, most-overdue first |
+| `journey progress --html` | Opens your personal dashboard (heatmap, streak, weak skills) |
+| `journey daily` | Today's recommended drill + challenge + reflection |
+
+All progress lives in `~/.journey/`. Your code lives in `workbook/` (gitignored — opt in to share via PR to `showcase/`).
 
 ---
 
@@ -101,6 +131,16 @@ Each per-topic file follows the same header structure as Java — `CONCEPT`, `KE
 Alongside the numbered topic files, each language folder also keeps an **overview/survey file** (`fundamentals.py`, `arrays.cpp`, `linked_lists.rs`, …) and `web/index.html` keeps the rich interactive page. These are quick-reference companions to the deep per-topic files.
 
 This layout supports going as deep in every language as the Java track, week by week.
+
+### Your workspace: `workbook/`
+
+A gitignored directory at the repo root. The journey CLI writes there:
+
+- `workbook/week_NN/attempts/` — your implementation attempts (one file per topic per date)
+- `workbook/week_NN/journal.md` — your reflection journal (`./journey reflect` appends here)
+- `workbook/week_NN/notes.md` — freeform notes you write
+
+See `workbook/README.md` for details.
 
 ## Table of Contents
 

--- a/Week 1/README.md
+++ b/Week 1/README.md
@@ -1,10 +1,34 @@
-# Week 1
+# Week 1 — Java Basics & I/O
 
-> Self-check: `./scripts/journey quiz 1` — run the mastery checkpoints for this week.
+> Self-check: `./scripts/journey quiz 1`  |  Next session: `./scripts/journey next`
 
-Each topic is implemented in all five languages: **Java, Python, C++, Rust, and Web (HTML/JS)**. The Java track is the primary detailed walkthrough; the others mirror it with idiomatic constructs.
+## Today's session (~30 min)
 
-## Topic index
+1. **Read & run** (15 min) — Walk through the python files in order: `1.*.py`, `2.*.py`, ... — actually run them.
+2. **Type along** (10 min) — Re-type 3 of them from scratch in `workbook/week_01/attempts/`. Don't copy-paste.
+3. **Self-check** (5 min) — `./scripts/journey quiz 1`
+
+Primary language: Python. Compare implementations in `java/`, `cpp/`, `rust/` to see how the same syntax looks across languages.
+
+---
+
+## Topic overview
+
+This week covers **Java Basics & I/O**. You'll touch: Java Installation, hello world, Better Hello World, Add two numbers, Arithmetic Operation, Taking Input. The flagship algorithm/concept for the week is implemented in all five languages, and the Python file listed in Today's session is the canonical walkthrough.
+
+## Related materials
+
+| Resource | Use it when |
+|----------|-------------|
+| [`problems.md`](problems.md) | You want extra practice with company-tagged problems |
+
+## Reference: per-language topic index
+
+<details>
+<summary>All implementations (Java / Python / C++ / Rust / Web)</summary>
+
+**Topic index**
+
 
 | # | Topic | Java | Python | C++ | Rust | Web |
 |---|-------|------|--------|-----|------|-----|
@@ -25,7 +49,8 @@ Each topic is implemented in all five languages: **Java, Python, C++, Rust, and 
 | 15 | Typecasting | `java/15.Typecasting.java` | `python/15.typecasting.py` | `cpp/15.typecasting.cpp` | `rust/s15_typecasting.rs` | `web/15.typecasting.html` |
 | 16 | Operators in java | `java/16.Operators_in_java` | `python/16.operators.py` | `cpp/16.operators.cpp` | `rust/s16_operators.rs` | `web/16.operators.html` |
 
-## Survey companions
+**Survey companions**
+
 
 Cross-cutting files that summarize the week or provide an interactive overview:
 
@@ -34,7 +59,64 @@ Cross-cutting files that summarize the week or provide an interactive overview:
 | Fundamentals | — | `python/fundamentals.py` | `cpp/fundamentals.cpp` | `rust/fundamentals.rs` | — |
 | Interactive index | — | — | — | — | `web/index.html` |
 
-## How to run a topic file
+**Topic roadmap**
+
+
+- **1. Java Installation**
+- **2. hello world**
+- **3. Better Hello World**
+- **4. Add two numbers**
+- **5. Arithmetic Operation**
+- **6. Taking Input**
+- **7. Taking Input all**
+- **8. Add two number better**
+- **9. Data Types**
+- **10. Multiple input**
+- **11. Integer and String**
+- **12. Average of two numbers**
+- **13. How Integer is Stored**
+- **14. How other datatype are stores**
+- **15. Typecasting**
+- **16. Operators in java**
+
+</details>
+
+## Reference: tradeoff matrix
+
+<details>
+<summary>Approach x Time x Space x When-to-prefer</summary>
+
+
+Flagship topic: reading input and printing output (Scanner vs BufferedReader vs args).
+
+| Approach | Time | Space | Code complexity | When to prefer |
+|----------|------|-------|-----------------|----------------|
+| `System.out.println` + `Scanner` | O(N) I/O | O(1) extra | Low | Tiny programs (< 10⁴ tokens), tutorials |
+| `BufferedReader` + `StringTokenizer` | O(N) I/O, ~5–10× faster | O(line) | Medium | Competitive programming, large inputs |
+| `DataInputStream` byte reader | O(N), fastest | O(buf) | High | Hot loops with 10⁶+ tokens |
+| Command-line `args[]` | O(args) | O(1) | Low | Fixed-size config, scripts driven by shell |
+
+</details>
+
+## Reference: anti-patterns to avoid
+
+<details>
+<summary>Common mistakes specific to this week's topic</summary>
+
+
+- **Calling `sc.nextInt()` then `sc.nextLine()` and being surprised the second returns empty** — `nextInt` leaves the trailing newline in the buffer; either consume it with an extra `nextLine()` or use `nextLine()` + `Integer.parseInt` consistently.
+- **Reusing one `Scanner` and closing it inside a helper** — closing a `Scanner` over `System.in` closes `System.in` itself, so later reads silently fail. Don't close stdin scanners.
+- **Mixing `int` and `double` in arithmetic and expecting fractional results** — `5/2` is `2`, not `2.5`. Cast one operand to `double` first, or use a `double` literal.
+- **Comparing strings with `==`** — `==` checks reference identity, not content. Use `.equals()`. This bites people on day one and never fully stops biting.
+- **Believing `int` can hold any number** — Java `int` overflows silently past 2³¹−1. Use `long` for products, factorials, or anything that could exceed ~2·10⁹.
+
+</details>
+
+## Reference: how to run a topic file
+
+<details>
+<summary>Java / Python / C++ / Rust / Web one-liners</summary>
+
 
 From the week's directory:
 
@@ -56,45 +138,10 @@ open web/<file>.html   # macOS
 xdg-open web/<file>.html   # Linux
 ```
 
-## Topic roadmap
-
-- **1. Java Installation**
-- **2. hello world**
-- **3. Better Hello World**
-- **4. Add two numbers**
-- **5. Arithmetic Operation**
-- **6. Taking Input**
-- **7. Taking Input all**
-- **8. Add two number better**
-- **9. Data Types**
-- **10. Multiple input**
-- **11. Integer and String**
-- **12. Average of two numbers**
-- **13. How Integer is Stored**
-- **14. How other datatype are stores**
-- **15. Typecasting**
-- **16. Operators in java**
-
-## Tradeoff Matrix
-
-Flagship topic: reading input and printing output (Scanner vs BufferedReader vs args).
-
-| Approach | Time | Space | Code complexity | When to prefer |
-|----------|------|-------|-----------------|----------------|
-| `System.out.println` + `Scanner` | O(N) I/O | O(1) extra | Low | Tiny programs (< 10⁴ tokens), tutorials |
-| `BufferedReader` + `StringTokenizer` | O(N) I/O, ~5–10× faster | O(line) | Medium | Competitive programming, large inputs |
-| `DataInputStream` byte reader | O(N), fastest | O(buf) | High | Hot loops with 10⁶+ tokens |
-| Command-line `args[]` | O(args) | O(1) | Low | Fixed-size config, scripts driven by shell |
-
-## Anti-patterns to avoid
-
-- **Calling `sc.nextInt()` then `sc.nextLine()` and being surprised the second returns empty** — `nextInt` leaves the trailing newline in the buffer; either consume it with an extra `nextLine()` or use `nextLine()` + `Integer.parseInt` consistently.
-- **Reusing one `Scanner` and closing it inside a helper** — closing a `Scanner` over `System.in` closes `System.in` itself, so later reads silently fail. Don't close stdin scanners.
-- **Mixing `int` and `double` in arithmetic and expecting fractional results** — `5/2` is `2`, not `2.5`. Cast one operand to `double` first, or use a `double` literal.
-- **Comparing strings with `==`** — `==` checks reference identity, not content. Use `.equals()`. This bites people on day one and never fully stops biting.
-- **Believing `int` can hold any number** — Java `int` overflows silently past 2³¹−1. Use `long` for products, factorials, or anything that could exceed ~2·10⁹.
+</details>
 
 ## Reflection prompts
+
 
 - Which topic this week was hardest, and what made it hard?
 - Was there a pattern you didn't recognize and had to be told about? Which one?

--- a/Week 10/README.md
+++ b/Week 10/README.md
@@ -1,17 +1,48 @@
-# Week 10
+# Week 10 — 2D Arrays & Matrix
 
-> Self-check: `./scripts/journey quiz 10` — run the mastery checkpoints for this week.
+> Self-check: `./scripts/journey quiz 10`  |  Next session: `./scripts/journey next`
 
-Each topic is implemented in all five languages: **Java, Python, C++, Rust, and Web (HTML/JS)**. The Java track is the primary detailed walkthrough; the others mirror it with idiomatic constructs.
+## Today's session (~45 min)
 
-## Topic index
+1. **Concept** (10 min) — Read [`python/2.spiral_and_diagonal_traversal.py`](python/2.spiral_and_diagonal_traversal.py) (CONCEPT + KEY POINTS blocks).
+2. **Recognize the pattern** (5 min) — Try drills 1-5 in [`patterns.md`](patterns.md) cold.
+3. **Implement from spec** (20 min) — Pick Challenge 1 from [`challenges.md`](challenges.md). Code it in `workbook/week_10/attempts/`.
+4. **Verify YOUR code** (5 min) — `./scripts/journey verify spiral_traversal workbook/week_10/attempts/<your-file>.py`
+5. **Mastery quiz** (5 min) — `./scripts/journey quiz 10`
+
+If you got stuck: open [`python/2.spiral_and_diagonal_traversal.py`](python/2.spiral_and_diagonal_traversal.py) and diff against your attempt.
+If you finish early: drills 6-10 in `patterns.md`, or Challenge 2.
+
+**Primary language: Python.** Want to compare implementations? See the per-language table below.
+
+---
+
+## Topic overview
+
+This week covers **2D Arrays & Matrix**. You'll touch: MatrixBasics, SpiralAndDiagonalTraversal. The flagship algorithm/concept for the week is implemented in all five languages, and the Python file listed in Today's session is the canonical walkthrough.
+
+## Related materials
+
+| Resource | Use it when |
+|----------|-------------|
+| Capstone: [`capstones/phase_2_text_search_tool.md`](../capstones/phase_2_text_search_tool.md) | Phase 2 capstone — apply what you learned in weeks 6-10 |
+| [`problems.md`](problems.md) | You want extra practice with company-tagged problems |
+
+## Reference: per-language topic index
+
+<details>
+<summary>All implementations (Java / Python / C++ / Rust / Web)</summary>
+
+**Topic index**
+
 
 | # | Topic | Java | Python | C++ | Rust | Web |
 |---|-------|------|--------|-----|------|-----|
 | 1 | MatrixBasics | `java/1.MatrixBasics.java` | `python/1.matrix_basics.py` | `cpp/1.matrix_basics.cpp` | `rust/s01_matrix_basics.rs` | `web/1.matrix_basics.html` |
 | 2 | SpiralAndDiagonalTraversal | `java/2.SpiralAndDiagonalTraversal.java` | `python/2.spiral_and_diagonal_traversal.py` | `cpp/2.spiral_and_diagonal_traversal.cpp` | `rust/s02_spiral_and_diagonal_traversal.rs` | `web/2.spiral_and_diagonal_traversal.html` |
 
-## Survey companions
+**Survey companions**
+
 
 Cross-cutting files that summarize the week or provide an interactive overview:
 
@@ -20,7 +51,55 @@ Cross-cutting files that summarize the week or provide an interactive overview:
 | Matrix | — | `python/matrix.py` | `cpp/matrix.cpp` | `rust/matrix.rs` | — |
 | Interactive index | — | — | — | — | `web/index.html` |
 
-## How to run a topic file
+**Topic roadmap**
+
+
+- **1. MatrixBasics**
+- **2. SpiralAndDiagonalTraversal**
+
+</details>
+
+## Reference: tradeoff matrix
+
+<details>
+<summary>Approach x Time x Space x When-to-prefer</summary>
+
+
+Flagship topic: 2-D matrix traversal (spiral order, diagonals).
+
+| Approach | Time | Space | Code complexity | When to prefer |
+|----------|------|-------|-----------------|----------------|
+| Four-boundary shrinking (top/bottom/left/right) | O(R·C) | O(1) | Medium | Spiral traversal — clearest invariant |
+| Direction-vector + visited matrix | O(R·C) | O(R·C) | Medium | When the boundary logic feels error-prone |
+| Layer-by-layer recursion | O(R·C) | O(min(R,C)) | High | Pedagogy; rotating a matrix in layers |
+| Transpose + reverse (for rotation) | O(R·C) | O(1) | Low | 90° rotation of a square matrix |
+
+| Approach (search in sorted matrix) | Time | Space | Code complexity | When to prefer |
+|----------|------|-------|-----------------|----------------|
+| Treat as flat array, binary search | O(log(R·C)) | O(1) | Low | Strictly row-major sorted matrix |
+| Staircase search from top-right | O(R+C) | O(1) | Low | Each row and column sorted independently |
+
+</details>
+
+## Reference: anti-patterns to avoid
+
+<details>
+<summary>Common mistakes specific to this week's topic</summary>
+
+
+- **Indexing `matrix[col][row]` because that's how you'd say "x, y"** — Java is row-major: `matrix[row][col]`. Mixing these gives you ArrayIndexOutOfBounds in some cases and silently-wrong answers in square matrices.
+- **Allocating a new matrix to rotate in place** — defeats the "in place" requirement. Use the transpose-then-reverse trick to rotate with O(1) extra space.
+- **Boundary checks scattered through a four-direction step** — collect into one helper `inBounds(r, c)`. Inlining `r >= 0 && r < R && c >= 0 && c < C` four times is where typos live.
+- **Forgetting to update the boundary when shrinking in a spiral** — after walking a side, you must move the corresponding boundary inward *before* checking the loop condition. Doing it after produces duplicate visits or skips on odd dimensions.
+- **Treating a jagged 2-D array as rectangular** — `matrix[i].length` can differ per row in Java. Cache row length once per row.
+
+</details>
+
+## Reference: how to run a topic file
+
+<details>
+<summary>Java / Python / C++ / Rust / Web one-liners</summary>
+
 
 From the week's directory:
 
@@ -42,36 +121,10 @@ open web/<file>.html   # macOS
 xdg-open web/<file>.html   # Linux
 ```
 
-## Topic roadmap
-
-- **1. MatrixBasics**
-- **2. SpiralAndDiagonalTraversal**
-
-## Tradeoff Matrix
-
-Flagship topic: 2-D matrix traversal (spiral order, diagonals).
-
-| Approach | Time | Space | Code complexity | When to prefer |
-|----------|------|-------|-----------------|----------------|
-| Four-boundary shrinking (top/bottom/left/right) | O(R·C) | O(1) | Medium | Spiral traversal — clearest invariant |
-| Direction-vector + visited matrix | O(R·C) | O(R·C) | Medium | When the boundary logic feels error-prone |
-| Layer-by-layer recursion | O(R·C) | O(min(R,C)) | High | Pedagogy; rotating a matrix in layers |
-| Transpose + reverse (for rotation) | O(R·C) | O(1) | Low | 90° rotation of a square matrix |
-
-| Approach (search in sorted matrix) | Time | Space | Code complexity | When to prefer |
-|----------|------|-------|-----------------|----------------|
-| Treat as flat array, binary search | O(log(R·C)) | O(1) | Low | Strictly row-major sorted matrix |
-| Staircase search from top-right | O(R+C) | O(1) | Low | Each row and column sorted independently |
-
-## Anti-patterns to avoid
-
-- **Indexing `matrix[col][row]` because that's how you'd say "x, y"** — Java is row-major: `matrix[row][col]`. Mixing these gives you ArrayIndexOutOfBounds in some cases and silently-wrong answers in square matrices.
-- **Allocating a new matrix to rotate in place** — defeats the "in place" requirement. Use the transpose-then-reverse trick to rotate with O(1) extra space.
-- **Boundary checks scattered through a four-direction step** — collect into one helper `inBounds(r, c)`. Inlining `r >= 0 && r < R && c >= 0 && c < C` four times is where typos live.
-- **Forgetting to update the boundary when shrinking in a spiral** — after walking a side, you must move the corresponding boundary inward *before* checking the loop condition. Doing it after produces duplicate visits or skips on odd dimensions.
-- **Treating a jagged 2-D array as rectangular** — `matrix[i].length` can differ per row in Java. Cache row length once per row.
+</details>
 
 ## Reflection prompts
+
 
 - Which topic this week was hardest, and what made it hard?
 - Was there a pattern you didn't recognize and had to be told about? Which one?

--- a/Week 11/README.md
+++ b/Week 11/README.md
@@ -1,17 +1,48 @@
-# Week 11
+# Week 11 — Linked Lists
 
-> Self-check: `./scripts/journey quiz 11` — run the mastery checkpoints for this week.
+> Self-check: `./scripts/journey quiz 11`  |  Next session: `./scripts/journey next`
 
-Each topic is implemented in all five languages: **Java, Python, C++, Rust, and Web (HTML/JS)**. The Java track is the primary detailed walkthrough; the others mirror it with idiomatic constructs.
+## Today's session (~45 min)
 
-## Topic index
+1. **Concept** (10 min) — Read [`python/1.SinglyLinkedList.py`](python/1.SinglyLinkedList.py) (CONCEPT + KEY POINTS blocks).
+2. **Recognize the pattern** (5 min) — Try drills 1-5 in [`patterns.md`](patterns.md) cold.
+3. **Implement from spec** (20 min) — Pick Challenge 1 from [`challenges.md`](challenges.md). Code it in `workbook/week_11/attempts/`.
+4. **Verify YOUR code** (5 min) — `./scripts/journey verify reverse_linked_list workbook/week_11/attempts/<your-file>.py`
+5. **Mastery quiz** (5 min) — `./scripts/journey quiz 11`
+
+If you got stuck: open [`python/1.SinglyLinkedList.py`](python/1.SinglyLinkedList.py) and diff against your attempt.
+If you finish early: drills 6-10 in `patterns.md`, or Challenge 2.
+
+**Primary language: Python.** Want to compare implementations? See the per-language table below.
+
+---
+
+## Topic overview
+
+This week covers **Linked Lists**. You'll touch: SinglyLinkedList, MergeSortedListsAndLRU. The flagship algorithm/concept for the week is implemented in all five languages, and the Python file listed in Today's session is the canonical walkthrough.
+
+## Related materials
+
+| Resource | Use it when |
+|----------|-------------|
+| Mock interview: [`mock_interviews/03_lru_cache.md`](../mock_interviews/03_lru_cache.md) | Linked list + LRU cache discussed conversationally |
+| [`problems.md`](problems.md) | You want extra practice with company-tagged problems |
+
+## Reference: per-language topic index
+
+<details>
+<summary>All implementations (Java / Python / C++ / Rust / Web)</summary>
+
+**Topic index**
+
 
 | # | Topic | Java | Python | C++ | Rust | Web |
 |---|-------|------|--------|-----|------|-----|
 | 1 | SinglyLinkedList | `java/1.SinglyLinkedList.java` | `python/1.SinglyLinkedList.py` | `cpp/1.SinglyLinkedList.cpp` | `rust/s01_SinglyLinkedList.rs` | `web/1.SinglyLinkedList.html` |
 | 2 | MergeSortedListsAndLRU | `java/2.MergeSortedListsAndLRU.java` | `python/2.MergeSortedListsAndLRU.py` | `cpp/2.MergeSortedListsAndLRU.cpp` | `rust/s02_MergeSortedListsAndLRU.rs` | `web/2.MergeSortedListsAndLRU.html` |
 
-## Survey companions
+**Survey companions**
+
 
 Cross-cutting files that summarize the week or provide an interactive overview:
 
@@ -20,7 +51,55 @@ Cross-cutting files that summarize the week or provide an interactive overview:
 | Linked Lists | — | `python/linked_lists.py` | `cpp/linked_lists.cpp` | `rust/linked_lists.rs` | — |
 | Interactive index | — | — | — | — | `web/index.html` |
 
-## How to run a topic file
+**Topic roadmap**
+
+
+- **1. SinglyLinkedList**
+- **2. MergeSortedListsAndLRU**
+
+</details>
+
+## Reference: tradeoff matrix
+
+<details>
+<summary>Approach x Time x Space x When-to-prefer</summary>
+
+
+Flagship topic: Linked List operations (singly LL, merge two sorted lists, LRU cache).
+
+| Approach (reverse linked list) | Time | Space | Code complexity | When to prefer |
+|----------|------|-------|-----------------|----------------|
+| Iterative three-pointer (`prev`, `curr`, `next`) | O(N) | O(1) | Low | Default — clean and O(1) space |
+| Recursive | O(N) | O(N) stack | Medium | When recursion is asked for; risks stack overflow on long lists |
+| Stack-based | O(N) | O(N) | Low | Pedagogy; never optimal |
+
+| Approach (LRU cache) | Time per op | Space | Code complexity | When to prefer |
+|----------|------|-------|-----------------|----------------|
+| HashMap + doubly linked list | O(1) | O(capacity) | Medium | Canonical interview answer |
+| `LinkedHashMap` (`accessOrder=true`) | O(1) | O(capacity) | Low | When you can use the JDK's built-in |
+| Array + timestamps | O(N) lookup | O(capacity) | Low | Tiny caches only |
+
+</details>
+
+## Reference: anti-patterns to avoid
+
+<details>
+<summary>Common mistakes specific to this week's topic</summary>
+
+
+- **Forgetting to handle the head-pointer change** — operations that may delete or insert at the head must return the (possibly new) head, or you'll silently leak/skip nodes. Use a sentinel/dummy node to make head-and-rest uniform.
+- **Updating only one direction in a doubly linked list** — every insert/delete needs four pointer updates. Miss one and you get a list that walks fine forward but crashes backward.
+- **Using `.equals` on node references when you mean identity** — for cycle detection or pointer comparisons you want `==`, not `.equals`. Two different nodes can be "equal" by value but are still distinct.
+- **Floyd's cycle detection started with both pointers at head and a `while (slow != fast)`** — they're equal at the start, so the loop never executes. Initialize one pointer ahead, or check inside the body.
+- **Implementing LRU with only a HashMap** — you also need ordering. A `HashMap` gives O(1) lookup but no eviction order; without the linked list (or `LinkedHashMap`) you can't find the least-recent in O(1).
+
+</details>
+
+## Reference: how to run a topic file
+
+<details>
+<summary>Java / Python / C++ / Rust / Web one-liners</summary>
+
 
 From the week's directory:
 
@@ -42,36 +121,10 @@ open web/<file>.html   # macOS
 xdg-open web/<file>.html   # Linux
 ```
 
-## Topic roadmap
-
-- **1. SinglyLinkedList**
-- **2. MergeSortedListsAndLRU**
-
-## Tradeoff Matrix
-
-Flagship topic: Linked List operations (singly LL, merge two sorted lists, LRU cache).
-
-| Approach (reverse linked list) | Time | Space | Code complexity | When to prefer |
-|----------|------|-------|-----------------|----------------|
-| Iterative three-pointer (`prev`, `curr`, `next`) | O(N) | O(1) | Low | Default — clean and O(1) space |
-| Recursive | O(N) | O(N) stack | Medium | When recursion is asked for; risks stack overflow on long lists |
-| Stack-based | O(N) | O(N) | Low | Pedagogy; never optimal |
-
-| Approach (LRU cache) | Time per op | Space | Code complexity | When to prefer |
-|----------|------|-------|-----------------|----------------|
-| HashMap + doubly linked list | O(1) | O(capacity) | Medium | Canonical interview answer |
-| `LinkedHashMap` (`accessOrder=true`) | O(1) | O(capacity) | Low | When you can use the JDK's built-in |
-| Array + timestamps | O(N) lookup | O(capacity) | Low | Tiny caches only |
-
-## Anti-patterns to avoid
-
-- **Forgetting to handle the head-pointer change** — operations that may delete or insert at the head must return the (possibly new) head, or you'll silently leak/skip nodes. Use a sentinel/dummy node to make head-and-rest uniform.
-- **Updating only one direction in a doubly linked list** — every insert/delete needs four pointer updates. Miss one and you get a list that walks fine forward but crashes backward.
-- **Using `.equals` on node references when you mean identity** — for cycle detection or pointer comparisons you want `==`, not `.equals`. Two different nodes can be "equal" by value but are still distinct.
-- **Floyd's cycle detection started with both pointers at head and a `while (slow != fast)`** — they're equal at the start, so the loop never executes. Initialize one pointer ahead, or check inside the body.
-- **Implementing LRU with only a HashMap** — you also need ordering. A `HashMap` gives O(1) lookup but no eviction order; without the linked list (or `LinkedHashMap`) you can't find the least-recent in O(1).
+</details>
 
 ## Reflection prompts
+
 
 - Which topic this week was hardest, and what made it hard?
 - Was there a pattern you didn't recognize and had to be told about? Which one?

--- a/Week 12/README.md
+++ b/Week 12/README.md
@@ -1,16 +1,46 @@
-# Week 12
+# Week 12 — Stacks
 
-> Self-check: `./scripts/journey quiz 12` — run the mastery checkpoints for this week.
+> Self-check: `./scripts/journey quiz 12`  |  Next session: `./scripts/journey next`
 
-Each topic is implemented in all five languages: **Java, Python, C++, Rust, and Web (HTML/JS)**. The Java track is the primary detailed walkthrough; the others mirror it with idiomatic constructs.
+## Today's session (~45 min)
 
-## Topic index
+1. **Concept** (10 min) — Read [`python/1.StackImplementation.py`](python/1.StackImplementation.py) (CONCEPT + KEY POINTS blocks).
+2. **Recognize the pattern** (5 min) — Try drills 1-5 in [`patterns.md`](patterns.md) cold.
+3. **Implement from spec** (20 min) — Pick Challenge 1 from [`challenges.md`](challenges.md). Code it in `workbook/week_12/attempts/`.
+4. **Verify YOUR code** (5 min) — `./scripts/journey verify balanced_parens workbook/week_12/attempts/<your-file>.py`
+5. **Mastery quiz** (5 min) — `./scripts/journey quiz 12`
+
+If you got stuck: open [`python/1.StackImplementation.py`](python/1.StackImplementation.py) and diff against your attempt.
+If you finish early: drills 6-10 in `patterns.md`, or Challenge 2.
+
+**Primary language: Python.** Want to compare implementations? See the per-language table below.
+
+---
+
+## Topic overview
+
+This week covers **Stacks**. You'll touch: StackImplementation. The flagship algorithm/concept for the week is implemented in all five languages, and the Python file listed in Today's session is the canonical walkthrough.
+
+## Related materials
+
+| Resource | Use it when |
+|----------|-------------|
+| [`problems.md`](problems.md) | You want extra practice with company-tagged problems |
+
+## Reference: per-language topic index
+
+<details>
+<summary>All implementations (Java / Python / C++ / Rust / Web)</summary>
+
+**Topic index**
+
 
 | # | Topic | Java | Python | C++ | Rust | Web |
 |---|-------|------|--------|-----|------|-----|
 | 1 | StackImplementation | `java/1.StackImplementation.java` | `python/1.StackImplementation.py` | `cpp/1.StackImplementation.cpp` | `rust/s01_StackImplementation.rs` | `web/1.StackImplementation.html` |
 
-## Survey companions
+**Survey companions**
+
 
 Cross-cutting files that summarize the week or provide an interactive overview:
 
@@ -19,7 +49,55 @@ Cross-cutting files that summarize the week or provide an interactive overview:
 | Stacks | — | `python/stacks.py` | `cpp/stacks.cpp` | `rust/stacks.rs` | — |
 | Interactive index | — | — | — | — | `web/index.html` |
 
-## How to run a topic file
+**Topic roadmap**
+
+
+- **1. StackImplementation**
+
+</details>
+
+## Reference: tradeoff matrix
+
+<details>
+<summary>Approach x Time x Space x When-to-prefer</summary>
+
+
+Flagship topic: Stack implementation and usage.
+
+| Approach | Time per op | Space | Code complexity | When to prefer |
+|----------|------|-------|-----------------|----------------|
+| `java.util.Stack` | O(1) amortized | O(N) | Lowest | Quick prototypes; legacy code |
+| `ArrayDeque` (recommended) | O(1) amortized | O(N) | Low | Production — `Stack` is synchronized and slow |
+| `LinkedList` as stack | O(1) | O(N) | Low | Rare — worse cache behavior than `ArrayDeque` |
+| Hand-rolled array-backed stack | O(1) amortized | O(N) | Medium | Learning the resize/doubling pattern |
+| Hand-rolled linked-node stack | O(1) | O(N) | Medium | When you need true O(1) push (no resize pauses) |
+
+| Approach (next greater element) | Time | Space | When to prefer |
+|----------|------|-------|----------------|
+| Brute force nested loop | O(N²) | O(1) | N ≤ 10³ |
+| Monotonic decreasing stack | O(N) | O(N) | Default — every "next greater/smaller" problem |
+
+</details>
+
+## Reference: anti-patterns to avoid
+
+<details>
+<summary>Common mistakes specific to this week's topic</summary>
+
+
+- **Using `java.util.Stack` in new code** — it extends `Vector`, which is synchronized; you pay locking cost you don't want, and the iteration order is bottom-to-top, which surprises people. Use `ArrayDeque`.
+- **Pushing onto an `ArrayDeque` with `addLast` and popping with `removeFirst`** — that's a queue, not a stack. For stack semantics use `push`/`pop` (which map to `addFirst`/`removeFirst`) consistently.
+- **Forgetting to check `isEmpty()` before `pop()`** — popping an empty stack throws `NoSuchElementException` (or `EmptyStackException` for the legacy class). Always guard, especially in matching-brackets problems.
+- **Implementing "min stack" with two stacks but pushing onto the min-stack every push** — wastes space. Only push when the new value is `<=` current min, and only pop when the popped value equals current min.
+- **Solving "valid parentheses" with a counter instead of a stack** — works for one bracket type but fails the moment you have `()[]{}` because a counter can't tell `(]` from `()`.
+
+</details>
+
+## Reference: how to run a topic file
+
+<details>
+<summary>Java / Python / C++ / Rust / Web one-liners</summary>
+
 
 From the week's directory:
 
@@ -41,36 +119,10 @@ open web/<file>.html   # macOS
 xdg-open web/<file>.html   # Linux
 ```
 
-## Topic roadmap
-
-- **1. StackImplementation**
-
-## Tradeoff Matrix
-
-Flagship topic: Stack implementation and usage.
-
-| Approach | Time per op | Space | Code complexity | When to prefer |
-|----------|------|-------|-----------------|----------------|
-| `java.util.Stack` | O(1) amortized | O(N) | Lowest | Quick prototypes; legacy code |
-| `ArrayDeque` (recommended) | O(1) amortized | O(N) | Low | Production — `Stack` is synchronized and slow |
-| `LinkedList` as stack | O(1) | O(N) | Low | Rare — worse cache behavior than `ArrayDeque` |
-| Hand-rolled array-backed stack | O(1) amortized | O(N) | Medium | Learning the resize/doubling pattern |
-| Hand-rolled linked-node stack | O(1) | O(N) | Medium | When you need true O(1) push (no resize pauses) |
-
-| Approach (next greater element) | Time | Space | When to prefer |
-|----------|------|-------|----------------|
-| Brute force nested loop | O(N²) | O(1) | N ≤ 10³ |
-| Monotonic decreasing stack | O(N) | O(N) | Default — every "next greater/smaller" problem |
-
-## Anti-patterns to avoid
-
-- **Using `java.util.Stack` in new code** — it extends `Vector`, which is synchronized; you pay locking cost you don't want, and the iteration order is bottom-to-top, which surprises people. Use `ArrayDeque`.
-- **Pushing onto an `ArrayDeque` with `addLast` and popping with `removeFirst`** — that's a queue, not a stack. For stack semantics use `push`/`pop` (which map to `addFirst`/`removeFirst`) consistently.
-- **Forgetting to check `isEmpty()` before `pop()`** — popping an empty stack throws `NoSuchElementException` (or `EmptyStackException` for the legacy class). Always guard, especially in matching-brackets problems.
-- **Implementing "min stack" with two stacks but pushing onto the min-stack every push** — wastes space. Only push when the new value is `<=` current min, and only pop when the popped value equals current min.
-- **Solving "valid parentheses" with a counter instead of a stack** — works for one bracket type but fails the moment you have `()[]{}` because a counter can't tell `(]` from `()`.
+</details>
 
 ## Reflection prompts
+
 
 - Which topic this week was hardest, and what made it hard?
 - Was there a pattern you didn't recognize and had to be told about? Which one?

--- a/Week 13/README.md
+++ b/Week 13/README.md
@@ -1,16 +1,46 @@
-# Week 13
+# Week 13 — Queues
 
-> Self-check: `./scripts/journey quiz 13` — run the mastery checkpoints for this week.
+> Self-check: `./scripts/journey quiz 13`  |  Next session: `./scripts/journey next`
 
-Each topic is implemented in all five languages: **Java, Python, C++, Rust, and Web (HTML/JS)**. The Java track is the primary detailed walkthrough; the others mirror it with idiomatic constructs.
+## Today's session (~45 min)
 
-## Topic index
+1. **Concept** (10 min) — Read [`python/1.QueueImplementation.py`](python/1.QueueImplementation.py) (CONCEPT + KEY POINTS blocks).
+2. **Recognize the pattern** (5 min) — Try drills 1-5 in [`patterns.md`](patterns.md) cold.
+3. **Implement from spec** (20 min) — Pick Challenge 1 from [`challenges.md`](challenges.md). Code it in `workbook/week_13/attempts/`.
+4. **Verify YOUR code** (5 min) — `./scripts/journey verify sliding_window_max workbook/week_13/attempts/<your-file>.py`
+5. **Mastery quiz** (5 min) — `./scripts/journey quiz 13`
+
+If you got stuck: open [`python/1.QueueImplementation.py`](python/1.QueueImplementation.py) and diff against your attempt.
+If you finish early: drills 6-10 in `patterns.md`, or Challenge 2.
+
+**Primary language: Python.** Want to compare implementations? See the per-language table below.
+
+---
+
+## Topic overview
+
+This week covers **Queues**. You'll touch: QueueImplementation. The flagship algorithm/concept for the week is implemented in all five languages, and the Python file listed in Today's session is the canonical walkthrough.
+
+## Related materials
+
+| Resource | Use it when |
+|----------|-------------|
+| [`problems.md`](problems.md) | You want extra practice with company-tagged problems |
+
+## Reference: per-language topic index
+
+<details>
+<summary>All implementations (Java / Python / C++ / Rust / Web)</summary>
+
+**Topic index**
+
 
 | # | Topic | Java | Python | C++ | Rust | Web |
 |---|-------|------|--------|-----|------|-----|
 | 1 | QueueImplementation | `java/1.QueueImplementation.java` | `python/1.QueueImplementation.py` | `cpp/1.QueueImplementation.cpp` | `rust/s01_QueueImplementation.rs` | `web/1.QueueImplementation.html` |
 
-## Survey companions
+**Survey companions**
+
 
 Cross-cutting files that summarize the week or provide an interactive overview:
 
@@ -19,7 +49,56 @@ Cross-cutting files that summarize the week or provide an interactive overview:
 | Queues | — | `python/queues.py` | `cpp/queues.cpp` | `rust/queues.rs` | — |
 | Interactive index | — | — | — | — | `web/index.html` |
 
-## How to run a topic file
+**Topic roadmap**
+
+
+- **1. QueueImplementation**
+
+</details>
+
+## Reference: tradeoff matrix
+
+<details>
+<summary>Approach x Time x Space x When-to-prefer</summary>
+
+
+Flagship topic: Queue implementation (array circular, linked, deque).
+
+| Approach | Time per op | Space | Code complexity | When to prefer |
+|----------|------|-------|-----------------|----------------|
+| `LinkedList` as `Queue` | O(1) | O(N) + per-node overhead | Low | Quick prototype |
+| `ArrayDeque` | O(1) amortized | O(N) | Low | Production default |
+| Hand-rolled circular array | O(1) | O(capacity) | Medium | Bounded queues, embedded systems |
+| Two stacks → queue | O(1) amortized | O(N) | Medium | Interview classic; teaches amortized analysis |
+| `java.util.concurrent` queues | O(1) | O(N) | Low | Cross-thread producer/consumer |
+
+| Approach (sliding window max) | Time | Space | When to prefer |
+|----------|------|-------|----------------|
+| Brute force | O(N·k) | O(1) | Tiny k |
+| Heap (priority queue) | O(N log k) | O(k) | When you also need order statistics |
+| Monotonic deque | O(N) | O(k) | Default — optimal |
+
+</details>
+
+## Reference: anti-patterns to avoid
+
+<details>
+<summary>Common mistakes specific to this week's topic</summary>
+
+
+- **Using `LinkedList` and accessing by index** — `get(i)` is O(N) on a linked list. If you need random access, use `ArrayList`/`ArrayDeque`, not `LinkedList`.
+- **Circular queue with `front == rear` ambiguity** — `front == rear` means both "empty" and "full" unless you track size separately or leave one slot unused. Pick one and document it.
+- **Calling `queue.remove()` to peek** — `remove()` removes and returns; `peek()`/`element()` look without removing. Confusing them eats your data.
+- **`null` element in a `Deque`** — `ArrayDeque` and most `Queue` implementations reject `null` because `null` is used as a sentinel for "empty". Storing `null` throws `NullPointerException`.
+- **Implementing BFS with a Stack** — BFS needs FIFO (a queue). Using a stack gives you DFS, which finds *a* path, not the shortest one.
+
+</details>
+
+## Reference: how to run a topic file
+
+<details>
+<summary>Java / Python / C++ / Rust / Web one-liners</summary>
+
 
 From the week's directory:
 
@@ -41,37 +120,10 @@ open web/<file>.html   # macOS
 xdg-open web/<file>.html   # Linux
 ```
 
-## Topic roadmap
-
-- **1. QueueImplementation**
-
-## Tradeoff Matrix
-
-Flagship topic: Queue implementation (array circular, linked, deque).
-
-| Approach | Time per op | Space | Code complexity | When to prefer |
-|----------|------|-------|-----------------|----------------|
-| `LinkedList` as `Queue` | O(1) | O(N) + per-node overhead | Low | Quick prototype |
-| `ArrayDeque` | O(1) amortized | O(N) | Low | Production default |
-| Hand-rolled circular array | O(1) | O(capacity) | Medium | Bounded queues, embedded systems |
-| Two stacks → queue | O(1) amortized | O(N) | Medium | Interview classic; teaches amortized analysis |
-| `java.util.concurrent` queues | O(1) | O(N) | Low | Cross-thread producer/consumer |
-
-| Approach (sliding window max) | Time | Space | When to prefer |
-|----------|------|-------|----------------|
-| Brute force | O(N·k) | O(1) | Tiny k |
-| Heap (priority queue) | O(N log k) | O(k) | When you also need order statistics |
-| Monotonic deque | O(N) | O(k) | Default — optimal |
-
-## Anti-patterns to avoid
-
-- **Using `LinkedList` and accessing by index** — `get(i)` is O(N) on a linked list. If you need random access, use `ArrayList`/`ArrayDeque`, not `LinkedList`.
-- **Circular queue with `front == rear` ambiguity** — `front == rear` means both "empty" and "full" unless you track size separately or leave one slot unused. Pick one and document it.
-- **Calling `queue.remove()` to peek** — `remove()` removes and returns; `peek()`/`element()` look without removing. Confusing them eats your data.
-- **`null` element in a `Deque`** — `ArrayDeque` and most `Queue` implementations reject `null` because `null` is used as a sentinel for "empty". Storing `null` throws `NullPointerException`.
-- **Implementing BFS with a Stack** — BFS needs FIFO (a queue). Using a stack gives you DFS, which finds *a* path, not the shortest one.
+</details>
 
 ## Reflection prompts
+
 
 - Which topic this week was hardest, and what made it hard?
 - Was there a pattern you didn't recognize and had to be told about? Which one?

--- a/Week 14/README.md
+++ b/Week 14/README.md
@@ -1,17 +1,47 @@
-# Week 14
+# Week 14 — Trees
 
-> Self-check: `./scripts/journey quiz 14` — run the mastery checkpoints for this week.
+> Self-check: `./scripts/journey quiz 14`  |  Next session: `./scripts/journey next`
 
-Each topic is implemented in all five languages: **Java, Python, C++, Rust, and Web (HTML/JS)**. The Java track is the primary detailed walkthrough; the others mirror it with idiomatic constructs.
+## Today's session (~45 min)
 
-## Topic index
+1. **Concept** (10 min) — Read [`python/2.BinarySearchTree.py`](python/2.BinarySearchTree.py) (CONCEPT + KEY POINTS blocks).
+2. **Recognize the pattern** (5 min) — Try drills 1-5 in [`patterns.md`](patterns.md) cold.
+3. **Implement from spec** (20 min) — Pick Challenge 1 from [`challenges.md`](challenges.md). Code it in `workbook/week_14/attempts/`.
+4. **Verify YOUR code** (5 min) — `./scripts/journey verify bst_validate workbook/week_14/attempts/<your-file>.py`
+5. **Mastery quiz** (5 min) — `./scripts/journey quiz 14`
+
+If you got stuck: open [`python/2.BinarySearchTree.py`](python/2.BinarySearchTree.py) and diff against your attempt.
+If you finish early: drills 6-10 in `patterns.md`, or Challenge 2.
+
+**Primary language: Python.** Want to compare implementations? See the per-language table below.
+
+---
+
+## Topic overview
+
+This week covers **Trees**. You'll touch: BinaryTree, BinarySearchTree. The flagship algorithm/concept for the week is implemented in all five languages, and the Python file listed in Today's session is the canonical walkthrough.
+
+## Related materials
+
+| Resource | Use it when |
+|----------|-------------|
+| [`problems.md`](problems.md) | You want extra practice with company-tagged problems |
+
+## Reference: per-language topic index
+
+<details>
+<summary>All implementations (Java / Python / C++ / Rust / Web)</summary>
+
+**Topic index**
+
 
 | # | Topic | Java | Python | C++ | Rust | Web |
 |---|-------|------|--------|-----|------|-----|
 | 1 | BinaryTree | `java/1.BinaryTree.java` | `python/1.BinaryTree.py` | `cpp/1.BinaryTree.cpp` | `rust/s01_BinaryTree.rs` | `web/1.BinaryTree.html` |
 | 2 | BinarySearchTree | `java/2.BinarySearchTree.java` | `python/2.BinarySearchTree.py` | `cpp/2.BinarySearchTree.cpp` | `rust/s02_BinarySearchTree.rs` | `web/2.BinarySearchTree.html` |
 
-## Survey companions
+**Survey companions**
+
 
 Cross-cutting files that summarize the week or provide an interactive overview:
 
@@ -20,7 +50,56 @@ Cross-cutting files that summarize the week or provide an interactive overview:
 | Trees | — | `python/trees.py` | `cpp/trees.cpp` | `rust/trees.rs` | — |
 | Interactive index | — | — | — | — | `web/index.html` |
 
-## How to run a topic file
+**Topic roadmap**
+
+
+- **1. BinaryTree**
+- **2. BinarySearchTree**
+
+</details>
+
+## Reference: tradeoff matrix
+
+<details>
+<summary>Approach x Time x Space x When-to-prefer</summary>
+
+
+Flagship topic: Binary Trees and Binary Search Trees.
+
+| Approach (tree traversal) | Time | Space | Code complexity | When to prefer |
+|----------|------|-------|-----------------|----------------|
+| Recursive DFS (pre/in/post) | O(N) | O(h) stack | Low | Default for balanced or moderate trees |
+| Iterative DFS with explicit stack | O(N) | O(h) | Medium | Skewed trees where recursion blows the stack |
+| Level-order BFS (queue) | O(N) | O(width) | Low | Level-by-level problems, shortest path in tree |
+| Morris traversal (threaded) | O(N) | O(1) | High | Constant-space requirement; modifies tree temporarily |
+
+| Approach (BST search/insert) | Time (avg) | Time (worst) | When to prefer |
+|----------|------|------|----------------|
+| Plain BST | O(log N) | O(N) | Random or shuffled inserts |
+| Self-balancing (AVL, Red-Black) | O(log N) | O(log N) | Worst-case guarantees needed |
+| `TreeMap` / `TreeSet` | O(log N) | O(log N) | Use the JDK — Red-Black under the hood |
+
+</details>
+
+## Reference: anti-patterns to avoid
+
+<details>
+<summary>Common mistakes specific to this week's topic</summary>
+
+
+- **Checking BST validity by comparing each node to only its parent** — a node can satisfy `parent < left ≤ parent < right` locally yet violate global ordering with a grandparent. Pass down `(min, max)` bounds, or do in-order traversal and verify it's strictly increasing.
+- **Building a BST from a sorted array by inserting in order** — produces a fully-skewed tree (a linked list). Use the recursive midpoint construction to get a balanced tree.
+- **Deleting a BST node by setting it to `null`** — only works if it has zero children. For one child, splice; for two children, replace with the in-order successor (or predecessor) and recurse.
+- **Computing tree height with `1 + max(left, right)` but forgetting the null base case** — returns wrong values or NPEs. The null subtree has height -1 (or 0, depending on convention); pick one and stay consistent.
+- **Recursing without considering skewed trees** — a 10⁶-deep right-skewed tree blows the default JVM stack (~10⁴ frames). Convert to iterative, or run on a `Thread` with a larger stack.
+
+</details>
+
+## Reference: how to run a topic file
+
+<details>
+<summary>Java / Python / C++ / Rust / Web one-liners</summary>
+
 
 From the week's directory:
 
@@ -42,37 +121,10 @@ open web/<file>.html   # macOS
 xdg-open web/<file>.html   # Linux
 ```
 
-## Topic roadmap
-
-- **1. BinaryTree**
-- **2. BinarySearchTree**
-
-## Tradeoff Matrix
-
-Flagship topic: Binary Trees and Binary Search Trees.
-
-| Approach (tree traversal) | Time | Space | Code complexity | When to prefer |
-|----------|------|-------|-----------------|----------------|
-| Recursive DFS (pre/in/post) | O(N) | O(h) stack | Low | Default for balanced or moderate trees |
-| Iterative DFS with explicit stack | O(N) | O(h) | Medium | Skewed trees where recursion blows the stack |
-| Level-order BFS (queue) | O(N) | O(width) | Low | Level-by-level problems, shortest path in tree |
-| Morris traversal (threaded) | O(N) | O(1) | High | Constant-space requirement; modifies tree temporarily |
-
-| Approach (BST search/insert) | Time (avg) | Time (worst) | When to prefer |
-|----------|------|------|----------------|
-| Plain BST | O(log N) | O(N) | Random or shuffled inserts |
-| Self-balancing (AVL, Red-Black) | O(log N) | O(log N) | Worst-case guarantees needed |
-| `TreeMap` / `TreeSet` | O(log N) | O(log N) | Use the JDK — Red-Black under the hood |
-
-## Anti-patterns to avoid
-
-- **Checking BST validity by comparing each node to only its parent** — a node can satisfy `parent < left ≤ parent < right` locally yet violate global ordering with a grandparent. Pass down `(min, max)` bounds, or do in-order traversal and verify it's strictly increasing.
-- **Building a BST from a sorted array by inserting in order** — produces a fully-skewed tree (a linked list). Use the recursive midpoint construction to get a balanced tree.
-- **Deleting a BST node by setting it to `null`** — only works if it has zero children. For one child, splice; for two children, replace with the in-order successor (or predecessor) and recurse.
-- **Computing tree height with `1 + max(left, right)` but forgetting the null base case** — returns wrong values or NPEs. The null subtree has height -1 (or 0, depending on convention); pick one and stay consistent.
-- **Recursing without considering skewed trees** — a 10⁶-deep right-skewed tree blows the default JVM stack (~10⁴ frames). Convert to iterative, or run on a `Thread` with a larger stack.
+</details>
 
 ## Reflection prompts
+
 
 - Which topic this week was hardest, and what made it hard?
 - Was there a pattern you didn't recognize and had to be told about? Which one?

--- a/Week 15/README.md
+++ b/Week 15/README.md
@@ -1,16 +1,48 @@
-# Week 15
+# Week 15 — Heaps & Priority Queues
 
-> Self-check: `./scripts/journey quiz 15` — run the mastery checkpoints for this week.
+> Self-check: `./scripts/journey quiz 15`  |  Next session: `./scripts/journey next`
 
-Each topic is implemented in all five languages: **Java, Python, C++, Rust, and Web (HTML/JS)**. The Java track is the primary detailed walkthrough; the others mirror it with idiomatic constructs.
+## Today's session (~45 min)
 
-## Topic index
+1. **Concept** (10 min) — Read [`python/1.HeapAndPriorityQueue.py`](python/1.HeapAndPriorityQueue.py) (CONCEPT + KEY POINTS blocks).
+2. **Recognize the pattern** (5 min) — Try drills 1-5 in [`patterns.md`](patterns.md) cold.
+3. **Implement from spec** (20 min) — Pick Challenge 1 from [`challenges.md`](challenges.md). Code it in `workbook/week_15/attempts/`.
+4. **Verify YOUR code** (5 min) — `./scripts/journey verify kth_largest workbook/week_15/attempts/<your-file>.py`
+5. **Mastery quiz** (5 min) — `./scripts/journey quiz 15`
+
+If you got stuck: open [`python/1.HeapAndPriorityQueue.py`](python/1.HeapAndPriorityQueue.py) and diff against your attempt.
+If you finish early: drills 6-10 in `patterns.md`, or Challenge 2.
+
+**Primary language: Python.** Want to compare implementations? See the per-language table below.
+
+---
+
+## Topic overview
+
+This week covers **Heaps & Priority Queues**. You'll touch: HeapAndPriorityQueue. The flagship algorithm/concept for the week is implemented in all five languages, and the Python file listed in Today's session is the canonical walkthrough.
+
+## Related materials
+
+| Resource | Use it when |
+|----------|-------------|
+| Mock interview: [`mock_interviews/03_lru_cache.md`](../mock_interviews/03_lru_cache.md) | Heap and LRU-style problems discussed conversationally |
+| Capstone: [`capstones/phase_3_visualizer_for_trees_and_heaps.md`](../capstones/phase_3_visualizer_for_trees_and_heaps.md) | Phase 3 capstone — apply what you learned in weeks 11-15 |
+| [`problems.md`](problems.md) | You want extra practice with company-tagged problems |
+
+## Reference: per-language topic index
+
+<details>
+<summary>All implementations (Java / Python / C++ / Rust / Web)</summary>
+
+**Topic index**
+
 
 | # | Topic | Java | Python | C++ | Rust | Web |
 |---|-------|------|--------|-----|------|-----|
 | 1 | HeapAndPriorityQueue | `java/1.HeapAndPriorityQueue.java` | `python/1.HeapAndPriorityQueue.py` | `cpp/1.HeapAndPriorityQueue.cpp` | `rust/s01_HeapAndPriorityQueue.rs` | `web/1.HeapAndPriorityQueue.html` |
 
-## Survey companions
+**Survey companions**
+
 
 Cross-cutting files that summarize the week or provide an interactive overview:
 
@@ -19,7 +51,56 @@ Cross-cutting files that summarize the week or provide an interactive overview:
 | Heaps | — | `python/heaps.py` | `cpp/heaps.cpp` | `rust/heaps.rs` | — |
 | Interactive index | — | — | — | — | `web/index.html` |
 
-## How to run a topic file
+**Topic roadmap**
+
+
+- **1. HeapAndPriorityQueue**
+
+</details>
+
+## Reference: tradeoff matrix
+
+<details>
+<summary>Approach x Time x Space x When-to-prefer</summary>
+
+
+Flagship topic: Heap / Priority Queue (and Kth-largest type problems).
+
+| Approach (Kth largest) | Time | Space | Code complexity | When to prefer |
+|----------|------|-------|-----------------|----------------|
+| Sort and pick index | O(N log N) | O(1) | Low | One-shot, small N |
+| Max-heap of size N, pop k times | O(N + k log N) | O(N) | Medium | k close to N |
+| Min-heap of size k | O(N log k) | O(k) | Medium | Streaming or k much smaller than N |
+| Quickselect | O(N) avg, O(N²) worst | O(1) | Medium | One-shot, large N, willing to randomize |
+| Counting sort variant | O(N + range) | O(range) | Low | Bounded integer keys |
+
+| Approach (merge k sorted lists) | Time | Space | When to prefer |
+|----------|------|-------|----------------|
+| Concatenate and sort | O(N log N) | O(N) | Tiny inputs |
+| Min-heap of heads | O(N log k) | O(k) | Default |
+| Pairwise merge (tournament) | O(N log k) | O(1) extra | When the lists are linked lists |
+
+</details>
+
+## Reference: anti-patterns to avoid
+
+<details>
+<summary>Common mistakes specific to this week's topic</summary>
+
+
+- **Using `PriorityQueue` and expecting iteration order to be sorted** — `PriorityQueue.iterator()` does *not* return elements in priority order. You must `poll()` them out.
+- **Comparator that returns `a - b` for `Integer`** — overflows for large or negative values (`Integer.MIN_VALUE - 1` wraps). Use `Integer.compare(a, b)`.
+- **Reusing a min-heap to find Kth largest with `peek()` after `N` inserts** — that gives you the smallest, not the kth largest. Either flip the comparator (max-heap) or keep size capped at k and `peek()` for kth largest.
+- **Rebuilding a heap after every update with `heapify`** — that's O(N) per update. Use `siftUp`/`siftDown` on the changed index for O(log N).
+- **Removing an arbitrary element via `pq.remove(x)`** — it's O(N) because it linearly searches. If you need decrease-key or arbitrary removal in O(log N), pair the heap with a HashMap of positions.
+
+</details>
+
+## Reference: how to run a topic file
+
+<details>
+<summary>Java / Python / C++ / Rust / Web one-liners</summary>
+
 
 From the week's directory:
 
@@ -41,37 +122,10 @@ open web/<file>.html   # macOS
 xdg-open web/<file>.html   # Linux
 ```
 
-## Topic roadmap
-
-- **1. HeapAndPriorityQueue**
-
-## Tradeoff Matrix
-
-Flagship topic: Heap / Priority Queue (and Kth-largest type problems).
-
-| Approach (Kth largest) | Time | Space | Code complexity | When to prefer |
-|----------|------|-------|-----------------|----------------|
-| Sort and pick index | O(N log N) | O(1) | Low | One-shot, small N |
-| Max-heap of size N, pop k times | O(N + k log N) | O(N) | Medium | k close to N |
-| Min-heap of size k | O(N log k) | O(k) | Medium | Streaming or k much smaller than N |
-| Quickselect | O(N) avg, O(N²) worst | O(1) | Medium | One-shot, large N, willing to randomize |
-| Counting sort variant | O(N + range) | O(range) | Low | Bounded integer keys |
-
-| Approach (merge k sorted lists) | Time | Space | When to prefer |
-|----------|------|-------|----------------|
-| Concatenate and sort | O(N log N) | O(N) | Tiny inputs |
-| Min-heap of heads | O(N log k) | O(k) | Default |
-| Pairwise merge (tournament) | O(N log k) | O(1) extra | When the lists are linked lists |
-
-## Anti-patterns to avoid
-
-- **Using `PriorityQueue` and expecting iteration order to be sorted** — `PriorityQueue.iterator()` does *not* return elements in priority order. You must `poll()` them out.
-- **Comparator that returns `a - b` for `Integer`** — overflows for large or negative values (`Integer.MIN_VALUE - 1` wraps). Use `Integer.compare(a, b)`.
-- **Reusing a min-heap to find Kth largest with `peek()` after `N` inserts** — that gives you the smallest, not the kth largest. Either flip the comparator (max-heap) or keep size capped at k and `peek()` for kth largest.
-- **Rebuilding a heap after every update with `heapify`** — that's O(N) per update. Use `siftUp`/`siftDown` on the changed index for O(log N).
-- **Removing an arbitrary element via `pq.remove(x)`** — it's O(N) because it linearly searches. If you need decrease-key or arbitrary removal in O(log N), pair the heap with a HashMap of positions.
+</details>
 
 ## Reflection prompts
+
 
 - Which topic this week was hardest, and what made it hard?
 - Was there a pattern you didn't recognize and had to be told about? Which one?

--- a/Week 16/README.md
+++ b/Week 16/README.md
@@ -1,16 +1,47 @@
-# Week 16
+# Week 16 — Hash Tables & Maps
 
-> Self-check: `./scripts/journey quiz 16` — run the mastery checkpoints for this week.
+> Self-check: `./scripts/journey quiz 16`  |  Next session: `./scripts/journey next`
 
-Each topic is implemented in all five languages: **Java, Python, C++, Rust, and Web (HTML/JS)**. The Java track is the primary detailed walkthrough; the others mirror it with idiomatic constructs.
+## Today's session (~45 min)
 
-## Topic index
+1. **Concept** (10 min) — Read [`python/1.HashingAndHashMap.py`](python/1.HashingAndHashMap.py) (CONCEPT + KEY POINTS blocks).
+2. **Recognize the pattern** (5 min) — Try drills 1-5 in [`patterns.md`](patterns.md) cold.
+3. **Implement from spec** (20 min) — Pick Challenge 1 from [`challenges.md`](challenges.md). Code it in `workbook/week_16/attempts/`.
+4. **Verify YOUR code** (5 min) — `./scripts/journey verify two_sum workbook/week_16/attempts/<your-file>.py`
+5. **Mastery quiz** (5 min) — `./scripts/journey quiz 16`
+
+If you got stuck: open [`python/1.HashingAndHashMap.py`](python/1.HashingAndHashMap.py) and diff against your attempt.
+If you finish early: drills 6-10 in `patterns.md`, or Challenge 2.
+
+**Primary language: Python.** Want to compare implementations? See the per-language table below.
+
+---
+
+## Topic overview
+
+This week covers **Hash Tables & Maps**. You'll touch: HashingAndHashMap. The flagship algorithm/concept for the week is implemented in all five languages, and the Python file listed in Today's session is the canonical walkthrough.
+
+## Related materials
+
+| Resource | Use it when |
+|----------|-------------|
+| Mock interview: [`mock_interviews/01_two_sum_warm_up.md`](../mock_interviews/01_two_sum_warm_up.md) | Hashing two-sum style problems in a conversation |
+| [`problems.md`](problems.md) | You want extra practice with company-tagged problems |
+
+## Reference: per-language topic index
+
+<details>
+<summary>All implementations (Java / Python / C++ / Rust / Web)</summary>
+
+**Topic index**
+
 
 | # | Topic | Java | Python | C++ | Rust | Web |
 |---|-------|------|--------|-----|------|-----|
 | 1 | HashingAndHashMap | `java/1.HashingAndHashMap.java` | `python/1.HashingAndHashMap.py` | `cpp/1.HashingAndHashMap.cpp` | `rust/s01_HashingAndHashMap.rs` | `web/1.HashingAndHashMap.html` |
 
-## Survey companions
+**Survey companions**
+
 
 Cross-cutting files that summarize the week or provide an interactive overview:
 
@@ -19,7 +50,56 @@ Cross-cutting files that summarize the week or provide an interactive overview:
 | Hashing | — | `python/hashing.py` | `cpp/hashing.cpp` | `rust/hashing.rs` | — |
 | Interactive index | — | — | — | — | `web/index.html` |
 
-## How to run a topic file
+**Topic roadmap**
+
+
+- **1. HashingAndHashMap**
+
+</details>
+
+## Reference: tradeoff matrix
+
+<details>
+<summary>Approach x Time x Space x When-to-prefer</summary>
+
+
+Flagship topic: Hashing and HashMap usage.
+
+| Approach (collision resolution) | Lookup time | Space | Code complexity | When to prefer |
+|----------|------|-------|-----------------|----------------|
+| Separate chaining (linked lists) | O(1) avg, O(N) worst | O(N) | Low | Default — what Java's HashMap uses |
+| Chaining with red-black trees (treeify) | O(log N) worst | O(N) | Medium | Java HashMap when a bucket exceeds 8 entries |
+| Open addressing (linear probing) | O(1) avg | O(N) | Medium | Cache-friendly, no per-entry pointers |
+| Cuckoo hashing | O(1) worst lookup | O(N) | High | When worst-case lookup matters |
+| Robin Hood / hopscotch | O(1) | O(N) | High | Specialized: low variance, predictable latency |
+
+| Approach (two-sum) | Time | Space | When to prefer |
+|----------|------|-------|----------------|
+| Brute force | O(N²) | O(1) | N ≤ 10³ |
+| Sort + two pointers | O(N log N) | O(1) extra | When you can mutate input and want low memory |
+| HashMap of complements | O(N) | O(N) | Default |
+
+</details>
+
+## Reference: anti-patterns to avoid
+
+<details>
+<summary>Common mistakes specific to this week's topic</summary>
+
+
+- **Overriding `equals` without overriding `hashCode`** — two objects "equal" by your definition land in different buckets, so the HashMap silently treats them as distinct. Override both, always.
+- **Using a mutable object as a HashMap key and mutating it** — once its hash changes, you can't find it in the map again. The entry becomes orphaned. Treat keys as effectively immutable.
+- **Iterating a HashMap and modifying it inside the loop** — throws `ConcurrentModificationException`. Use `iterator.remove()` or collect changes and apply afterwards.
+- **Relying on `HashMap` iteration order** — it's not guaranteed across JVM versions or even runs. Use `LinkedHashMap` for insertion order, `TreeMap` for sorted order.
+- **Building a "hash" with `s.charAt(0) * 31 + s.charAt(1)`** — collides absurdly often and ignores the rest of the string. Use `Objects.hash(...)` or `String.hashCode()` and trust the JDK.
+
+</details>
+
+## Reference: how to run a topic file
+
+<details>
+<summary>Java / Python / C++ / Rust / Web one-liners</summary>
+
 
 From the week's directory:
 
@@ -41,37 +121,10 @@ open web/<file>.html   # macOS
 xdg-open web/<file>.html   # Linux
 ```
 
-## Topic roadmap
-
-- **1. HashingAndHashMap**
-
-## Tradeoff Matrix
-
-Flagship topic: Hashing and HashMap usage.
-
-| Approach (collision resolution) | Lookup time | Space | Code complexity | When to prefer |
-|----------|------|-------|-----------------|----------------|
-| Separate chaining (linked lists) | O(1) avg, O(N) worst | O(N) | Low | Default — what Java's HashMap uses |
-| Chaining with red-black trees (treeify) | O(log N) worst | O(N) | Medium | Java HashMap when a bucket exceeds 8 entries |
-| Open addressing (linear probing) | O(1) avg | O(N) | Medium | Cache-friendly, no per-entry pointers |
-| Cuckoo hashing | O(1) worst lookup | O(N) | High | When worst-case lookup matters |
-| Robin Hood / hopscotch | O(1) | O(N) | High | Specialized: low variance, predictable latency |
-
-| Approach (two-sum) | Time | Space | When to prefer |
-|----------|------|-------|----------------|
-| Brute force | O(N²) | O(1) | N ≤ 10³ |
-| Sort + two pointers | O(N log N) | O(1) extra | When you can mutate input and want low memory |
-| HashMap of complements | O(N) | O(N) | Default |
-
-## Anti-patterns to avoid
-
-- **Overriding `equals` without overriding `hashCode`** — two objects "equal" by your definition land in different buckets, so the HashMap silently treats them as distinct. Override both, always.
-- **Using a mutable object as a HashMap key and mutating it** — once its hash changes, you can't find it in the map again. The entry becomes orphaned. Treat keys as effectively immutable.
-- **Iterating a HashMap and modifying it inside the loop** — throws `ConcurrentModificationException`. Use `iterator.remove()` or collect changes and apply afterwards.
-- **Relying on `HashMap` iteration order** — it's not guaranteed across JVM versions or even runs. Use `LinkedHashMap` for insertion order, `TreeMap` for sorted order.
-- **Building a "hash" with `s.charAt(0) * 31 + s.charAt(1)`** — collides absurdly often and ignores the rest of the string. Use `Objects.hash(...)` or `String.hashCode()` and trust the JDK.
+</details>
 
 ## Reflection prompts
+
 
 - Which topic this week was hardest, and what made it hard?
 - Was there a pattern you didn't recognize and had to be told about? Which one?

--- a/Week 17/README.md
+++ b/Week 17/README.md
@@ -1,17 +1,49 @@
-# Week 17
+# Week 17 — Graphs - Fundamentals & Traversals
 
-> Self-check: `./scripts/journey quiz 17` — run the mastery checkpoints for this week.
+> Self-check: `./scripts/journey quiz 17`  |  Next session: `./scripts/journey next`
 
-Each topic is implemented in all five languages: **Java, Python, C++, Rust, and Web (HTML/JS)**. The Java track is the primary detailed walkthrough; the others mirror it with idiomatic constructs.
+## Today's session (~45 min)
 
-## Topic index
+1. **Concept** (10 min) — Read [`python/2.TopologicalSort.py`](python/2.TopologicalSort.py) (CONCEPT + KEY POINTS blocks).
+2. **Recognize the pattern** (5 min) — Try drills 1-5 in [`patterns.md`](patterns.md) cold.
+3. **Implement from spec** (20 min) — Pick Challenge 1 from [`challenges.md`](challenges.md). Code it in `workbook/week_17/attempts/`.
+4. **Verify YOUR code** (5 min) — `./scripts/journey verify topological_sort workbook/week_17/attempts/<your-file>.py`
+5. **Mastery quiz** (5 min) — `./scripts/journey quiz 17`
+
+If you got stuck: open [`python/2.TopologicalSort.py`](python/2.TopologicalSort.py) and diff against your attempt.
+If you finish early: drills 6-10 in `patterns.md`, or Challenge 2.
+
+**Primary language: Python.** Want to compare implementations? See the per-language table below.
+
+---
+
+## Topic overview
+
+This week covers **Graphs - Fundamentals & Traversals**. You'll touch: GraphRepresentations, TopologicalSort. The flagship algorithm/concept for the week is implemented in all five languages, and the Python file listed in Today's session is the canonical walkthrough.
+
+## Related materials
+
+| Resource | Use it when |
+|----------|-------------|
+| Visualization: [`viz/bfs_dfs.html`](../viz/bfs_dfs.html) | You want to SEE BFS and DFS visit nodes step by step |
+| Mock interview: [`mock_interviews/04_word_ladder_bfs.md`](../mock_interviews/04_word_ladder_bfs.md) | Graph / BFS problems discussed conversationally |
+| [`problems.md`](problems.md) | You want extra practice with company-tagged problems |
+
+## Reference: per-language topic index
+
+<details>
+<summary>All implementations (Java / Python / C++ / Rust / Web)</summary>
+
+**Topic index**
+
 
 | # | Topic | Java | Python | C++ | Rust | Web |
 |---|-------|------|--------|-----|------|-----|
 | 1 | GraphRepresentations | `java/1.GraphRepresentations.java` | `python/1.GraphRepresentations.py` | `cpp/1.GraphRepresentations.cpp` | `rust/s01_GraphRepresentations.rs` | `web/1.GraphRepresentations.html` |
 | 2 | TopologicalSort | `java/2.TopologicalSort.java` | `python/2.TopologicalSort.py` | `cpp/2.TopologicalSort.cpp` | `rust/s02_TopologicalSort.rs` | `web/2.TopologicalSort.html` |
 
-## Survey companions
+**Survey companions**
+
 
 Cross-cutting files that summarize the week or provide an interactive overview:
 
@@ -20,7 +52,55 @@ Cross-cutting files that summarize the week or provide an interactive overview:
 | Graphs | — | `python/graphs.py` | `cpp/graphs.cpp` | `rust/graphs.rs` | — |
 | Interactive index | — | — | — | — | `web/index.html` |
 
-## How to run a topic file
+**Topic roadmap**
+
+
+- **1. GraphRepresentations**
+- **2. TopologicalSort**
+
+</details>
+
+## Reference: tradeoff matrix
+
+<details>
+<summary>Approach x Time x Space x When-to-prefer</summary>
+
+
+Flagship topic: Graph representations and Topological Sort.
+
+| Approach (graph representation) | Memory | Edge query | Neighbors | When to prefer |
+|----------|------|-------|-----------|----------------|
+| Adjacency matrix | O(V²) | O(1) | O(V) | Dense graphs (E ≈ V²), edge-existence queries |
+| Adjacency list (`List<List<Integer>>`) | O(V + E) | O(deg) | O(deg) | Default — sparse graphs |
+| Edge list | O(E) | O(E) | O(E) | Kruskal's MST; algorithms that iterate all edges |
+| CSR (compressed sparse row) | O(V + E) | O(log deg) | O(deg) | Cache-friendly, immutable graphs |
+
+| Approach (topological sort) | Time | Space | When to prefer |
+|----------|------|-------|----------------|
+| Kahn's algorithm (BFS, in-degrees) | O(V + E) | O(V) | Detects cycles cleanly; can produce lex-smallest order with a PQ |
+| DFS post-order reverse | O(V + E) | O(V) | When you're already doing DFS for other reasons |
+
+</details>
+
+## Reference: anti-patterns to avoid
+
+<details>
+<summary>Common mistakes specific to this week's topic</summary>
+
+
+- **Topological sort on a cyclic graph and pretending the output is valid** — Kahn's stops with nodes still having in-degree > 0; you must check `processed == V` and report the cycle, not silently return a partial order.
+- **Marking a node visited *after* recursing into its neighbors** — you'll revisit the same node many times, blowing up to exponential time. Mark visited *before* recursing.
+- **One `visited` array for cycle detection in a *directed* graph** — you need three states (unvisited / in-stack / done) to distinguish a cycle from a cross-edge to a finished node. Two states only work on undirected graphs.
+- **Adjacency-matrix for sparse graphs with V=10⁵** — that's a 10¹⁰-entry matrix; it won't fit in memory. Use an adjacency list.
+- **Building an undirected graph by adding `u → v` only** — every undirected edge needs both `u → v` and `v → u`. Forgetting the symmetric add is the most common reason BFS finds nothing.
+
+</details>
+
+## Reference: how to run a topic file
+
+<details>
+<summary>Java / Python / C++ / Rust / Web one-liners</summary>
+
 
 From the week's directory:
 
@@ -42,36 +122,10 @@ open web/<file>.html   # macOS
 xdg-open web/<file>.html   # Linux
 ```
 
-## Topic roadmap
-
-- **1. GraphRepresentations**
-- **2. TopologicalSort**
-
-## Tradeoff Matrix
-
-Flagship topic: Graph representations and Topological Sort.
-
-| Approach (graph representation) | Memory | Edge query | Neighbors | When to prefer |
-|----------|------|-------|-----------|----------------|
-| Adjacency matrix | O(V²) | O(1) | O(V) | Dense graphs (E ≈ V²), edge-existence queries |
-| Adjacency list (`List<List<Integer>>`) | O(V + E) | O(deg) | O(deg) | Default — sparse graphs |
-| Edge list | O(E) | O(E) | O(E) | Kruskal's MST; algorithms that iterate all edges |
-| CSR (compressed sparse row) | O(V + E) | O(log deg) | O(deg) | Cache-friendly, immutable graphs |
-
-| Approach (topological sort) | Time | Space | When to prefer |
-|----------|------|-------|----------------|
-| Kahn's algorithm (BFS, in-degrees) | O(V + E) | O(V) | Detects cycles cleanly; can produce lex-smallest order with a PQ |
-| DFS post-order reverse | O(V + E) | O(V) | When you're already doing DFS for other reasons |
-
-## Anti-patterns to avoid
-
-- **Topological sort on a cyclic graph and pretending the output is valid** — Kahn's stops with nodes still having in-degree > 0; you must check `processed == V` and report the cycle, not silently return a partial order.
-- **Marking a node visited *after* recursing into its neighbors** — you'll revisit the same node many times, blowing up to exponential time. Mark visited *before* recursing.
-- **One `visited` array for cycle detection in a *directed* graph** — you need three states (unvisited / in-stack / done) to distinguish a cycle from a cross-edge to a finished node. Two states only work on undirected graphs.
-- **Adjacency-matrix for sparse graphs with V=10⁵** — that's a 10¹⁰-entry matrix; it won't fit in memory. Use an adjacency list.
-- **Building an undirected graph by adding `u → v` only** — every undirected edge needs both `u → v` and `v → u`. Forgetting the symmetric add is the most common reason BFS finds nothing.
+</details>
 
 ## Reflection prompts
+
 
 - Which topic this week was hardest, and what made it hard?
 - Was there a pattern you didn't recognize and had to be told about? Which one?

--- a/Week 18/README.md
+++ b/Week 18/README.md
@@ -1,16 +1,48 @@
-# Week 18
+# Week 18 — Dynamic Programming
 
-> Self-check: `./scripts/journey quiz 18` — run the mastery checkpoints for this week.
+> Self-check: `./scripts/journey quiz 18`  |  Next session: `./scripts/journey next`
 
-Each topic is implemented in all five languages: **Java, Python, C++, Rust, and Web (HTML/JS)**. The Java track is the primary detailed walkthrough; the others mirror it with idiomatic constructs.
+## Today's session (~45 min)
 
-## Topic index
+1. **Concept** (10 min) — Read [`python/1.DynamicProgramming.py`](python/1.DynamicProgramming.py) (CONCEPT + KEY POINTS blocks).
+2. **Recognize the pattern** (5 min) — Try drills 1-5 in [`patterns.md`](patterns.md) cold.
+3. **Implement from spec** (20 min) — Pick Challenge 1 from [`challenges.md`](challenges.md). Code it in `workbook/week_18/attempts/`.
+4. **Verify YOUR code** (5 min) — `./scripts/journey verify coin_change workbook/week_18/attempts/<your-file>.py`
+5. **Mastery quiz** (5 min) — `./scripts/journey quiz 18`
+
+If you got stuck: open [`python/1.DynamicProgramming.py`](python/1.DynamicProgramming.py) and diff against your attempt.
+If you finish early: drills 6-10 in `patterns.md`, or Challenge 2.
+
+**Primary language: Python.** Want to compare implementations? See the per-language table below.
+
+---
+
+## Topic overview
+
+This week covers **Dynamic Programming**. You'll touch: DynamicProgramming. The flagship algorithm/concept for the week is implemented in all five languages, and the Python file listed in Today's session is the canonical walkthrough.
+
+## Related materials
+
+| Resource | Use it when |
+|----------|-------------|
+| Visualization: [`viz/dp_table.html`](../viz/dp_table.html) | You want to SEE the DP table fill in |
+| Mock interview: [`mock_interviews/05_dp_house_robber_iii.md`](../mock_interviews/05_dp_house_robber_iii.md) | DP problems discussed conversationally |
+| [`problems.md`](problems.md) | You want extra practice with company-tagged problems |
+
+## Reference: per-language topic index
+
+<details>
+<summary>All implementations (Java / Python / C++ / Rust / Web)</summary>
+
+**Topic index**
+
 
 | # | Topic | Java | Python | C++ | Rust | Web |
 |---|-------|------|--------|-----|------|-----|
 | 1 | DynamicProgramming | `java/1.DynamicProgramming.java` | `python/1.DynamicProgramming.py` | `cpp/1.DynamicProgramming.cpp` | `rust/s01_DynamicProgramming.rs` | `web/1.DynamicProgramming.html` |
 
-## Survey companions
+**Survey companions**
+
 
 Cross-cutting files that summarize the week or provide an interactive overview:
 
@@ -19,7 +51,50 @@ Cross-cutting files that summarize the week or provide an interactive overview:
 | Dynamic Programming | — | `python/dynamic_programming.py` | `cpp/dynamic_programming.cpp` | `rust/dynamic_programming.rs` | — |
 | Interactive index | — | — | — | — | `web/index.html` |
 
-## How to run a topic file
+**Topic roadmap**
+
+
+- **1. DynamicProgramming**
+
+</details>
+
+## Reference: tradeoff matrix
+
+<details>
+<summary>Approach x Time x Space x When-to-prefer</summary>
+
+
+Flagship topic: Dynamic Programming (0/1 knapsack, LIS, edit distance, coin change).
+
+| Approach | Time | Space | Code complexity | When to prefer |
+|----------|------|-------|-----------------|----------------|
+| Plain recursion | O(branches^depth) | O(depth) | Low | Sanity oracle, very small inputs |
+| Memoized recursion (top-down) | O(states · transition) | O(states + depth) | Medium | When state space is sparse or hard to enumerate |
+| Tabulation (bottom-up) | O(states · transition) | O(states) | Medium | When you need the full table, or to drop a dimension later |
+| Tabulation + rolling array | O(states · transition) | O(slice) | High | When memory is the bottleneck and you only need O(1) previous rows |
+| Closed form / math | O(1) or O(log N) | O(1) | Varies | Problems with a known formula (e.g. Catalan) |
+
+</details>
+
+## Reference: anti-patterns to avoid
+
+<details>
+<summary>Common mistakes specific to this week's topic</summary>
+
+
+- **Memoizing on a mutable state object** — if the memo key changes after lookup, you'll get cross-talk between unrelated states. Use immutable keys (tuples, encoded ints).
+- **Confusing 0/1 knapsack and unbounded knapsack** — the iteration order of the inner loop differs. For 0/1, iterate capacity *descending*; for unbounded, iterate *ascending*. Reversing the wrong one silently gives the wrong answer.
+- **Initializing the DP table to 0 when the identity element is `+∞` or `-∞`** — for "minimum" problems, 0 looks like a valid (and very good) answer. Initialize to `Integer.MAX_VALUE` / `MIN_VALUE` and handle saturation.
+- **Computing LIS in O(N²) when you need O(N log N)** — the longest-increasing-subsequence with patience-sort + binary search is the standard interview expectation. The O(N²) DP is fine pedagogically but won't pass tight constraints.
+- **Forgetting space optimization erases earlier states you'll still need** — rolling-array DP requires checking your transition only reads from the previous row(s). If it reads further back, you can't roll.
+
+</details>
+
+## Reference: how to run a topic file
+
+<details>
+<summary>Java / Python / C++ / Rust / Web one-liners</summary>
+
 
 From the week's directory:
 
@@ -41,31 +116,10 @@ open web/<file>.html   # macOS
 xdg-open web/<file>.html   # Linux
 ```
 
-## Topic roadmap
-
-- **1. DynamicProgramming**
-
-## Tradeoff Matrix
-
-Flagship topic: Dynamic Programming (0/1 knapsack, LIS, edit distance, coin change).
-
-| Approach | Time | Space | Code complexity | When to prefer |
-|----------|------|-------|-----------------|----------------|
-| Plain recursion | O(branches^depth) | O(depth) | Low | Sanity oracle, very small inputs |
-| Memoized recursion (top-down) | O(states · transition) | O(states + depth) | Medium | When state space is sparse or hard to enumerate |
-| Tabulation (bottom-up) | O(states · transition) | O(states) | Medium | When you need the full table, or to drop a dimension later |
-| Tabulation + rolling array | O(states · transition) | O(slice) | High | When memory is the bottleneck and you only need O(1) previous rows |
-| Closed form / math | O(1) or O(log N) | O(1) | Varies | Problems with a known formula (e.g. Catalan) |
-
-## Anti-patterns to avoid
-
-- **Memoizing on a mutable state object** — if the memo key changes after lookup, you'll get cross-talk between unrelated states. Use immutable keys (tuples, encoded ints).
-- **Confusing 0/1 knapsack and unbounded knapsack** — the iteration order of the inner loop differs. For 0/1, iterate capacity *descending*; for unbounded, iterate *ascending*. Reversing the wrong one silently gives the wrong answer.
-- **Initializing the DP table to 0 when the identity element is `+∞` or `-∞`** — for "minimum" problems, 0 looks like a valid (and very good) answer. Initialize to `Integer.MAX_VALUE` / `MIN_VALUE` and handle saturation.
-- **Computing LIS in O(N²) when you need O(N log N)** — the longest-increasing-subsequence with patience-sort + binary search is the standard interview expectation. The O(N²) DP is fine pedagogically but won't pass tight constraints.
-- **Forgetting space optimization erases earlier states you'll still need** — rolling-array DP requires checking your transition only reads from the previous row(s). If it reads further back, you can't roll.
+</details>
 
 ## Reflection prompts
+
 
 - Which topic this week was hardest, and what made it hard?
 - Was there a pattern you didn't recognize and had to be told about? Which one?

--- a/Week 19/README.md
+++ b/Week 19/README.md
@@ -1,16 +1,47 @@
-# Week 19
+# Week 19 — Greedy Algorithms
 
-> Self-check: `./scripts/journey quiz 19` — run the mastery checkpoints for this week.
+> Self-check: `./scripts/journey quiz 19`  |  Next session: `./scripts/journey next`
 
-Each topic is implemented in all five languages: **Java, Python, C++, Rust, and Web (HTML/JS)**. The Java track is the primary detailed walkthrough; the others mirror it with idiomatic constructs.
+## Today's session (~45 min)
 
-## Topic index
+1. **Concept** (10 min) — Read [`python/1.GreedyAlgorithms.py`](python/1.GreedyAlgorithms.py) (CONCEPT + KEY POINTS blocks).
+2. **Recognize the pattern** (5 min) — Try drills 1-5 in [`patterns.md`](patterns.md) cold.
+3. **Implement from spec** (20 min) — Pick Challenge 1 from [`challenges.md`](challenges.md). Code it in `workbook/week_19/attempts/`.
+4. **Verify YOUR code** (5 min) — `./scripts/journey verify activity_selection_sort workbook/week_19/attempts/<your-file>.py`
+5. **Mastery quiz** (5 min) — `./scripts/journey quiz 19`
+
+If you got stuck: open [`python/1.GreedyAlgorithms.py`](python/1.GreedyAlgorithms.py) and diff against your attempt.
+If you finish early: drills 6-10 in `patterns.md`, or Challenge 2.
+
+**Primary language: Python.** Want to compare implementations? See the per-language table below.
+
+---
+
+## Topic overview
+
+This week covers **Greedy Algorithms**. You'll touch: GreedyAlgorithms. The flagship algorithm/concept for the week is implemented in all five languages, and the Python file listed in Today's session is the canonical walkthrough.
+
+## Related materials
+
+| Resource | Use it when |
+|----------|-------------|
+| Mock interview: [`mock_interviews/02_meeting_rooms_intervals.md`](../mock_interviews/02_meeting_rooms_intervals.md) | Greedy / interval problems in a conversation |
+| [`problems.md`](problems.md) | You want extra practice with company-tagged problems |
+
+## Reference: per-language topic index
+
+<details>
+<summary>All implementations (Java / Python / C++ / Rust / Web)</summary>
+
+**Topic index**
+
 
 | # | Topic | Java | Python | C++ | Rust | Web |
 |---|-------|------|--------|-----|------|-----|
 | 1 | GreedyAlgorithms | `java/1.GreedyAlgorithms.java` | `python/1.GreedyAlgorithms.py` | `cpp/1.GreedyAlgorithms.cpp` | `rust/s01_GreedyAlgorithms.rs` | `web/1.GreedyAlgorithms.html` |
 
-## Survey companions
+**Survey companions**
+
 
 Cross-cutting files that summarize the week or provide an interactive overview:
 
@@ -19,7 +50,55 @@ Cross-cutting files that summarize the week or provide an interactive overview:
 | Greedy | — | `python/greedy.py` | `cpp/greedy.cpp` | `rust/greedy.rs` | — |
 | Interactive index | — | — | — | — | `web/index.html` |
 
-## How to run a topic file
+**Topic roadmap**
+
+
+- **1. GreedyAlgorithms**
+
+</details>
+
+## Reference: tradeoff matrix
+
+<details>
+<summary>Approach x Time x Space x When-to-prefer</summary>
+
+
+Flagship topic: Greedy algorithms (activity selection, fractional knapsack, Huffman).
+
+| Approach (interval scheduling) | Time | Space | Code complexity | When to prefer |
+|----------|------|-------|-----------------|----------------|
+| Brute force enumerate subsets | O(2ⁿ) | O(n) | Low | n ≤ 20, oracle for correctness |
+| DP on sorted intervals | O(N log N) | O(N) | Medium | Weighted interval scheduling |
+| Greedy by earliest finish time | O(N log N) | O(1) extra | Low | Unweighted activity selection — provably optimal |
+| Greedy by earliest start time | O(N log N) | O(1) | Low | **Wrong** for activity selection — counterexample exists |
+
+| Approach (knapsack) | Time | Space | When to prefer |
+|----------|------|-------|----------------|
+| Greedy by value/weight ratio | O(N log N) | O(1) | Fractional knapsack — optimal |
+| Greedy by ratio (0/1 version) | O(N log N) | O(1) | **Heuristic only** — can be arbitrarily bad |
+| DP | O(N·W) | O(W) | 0/1 knapsack — correct |
+
+</details>
+
+## Reference: anti-patterns to avoid
+
+<details>
+<summary>Common mistakes specific to this week's topic</summary>
+
+
+- **Reaching for greedy because the problem "feels easy"** — greedy is correct only when the problem has the *exchange* / *matroid* property. Always sketch a counterexample attempt before committing.
+- **Sorting by the wrong key** — interval scheduling needs finish time, not start time or duration. The choice of key is the entire algorithm; getting it wrong yields a plausible-looking algorithm that fails on adversarial inputs.
+- **Confusing greedy correctness with greedy efficiency** — even a correct greedy strategy needs O(N log N) sorting; calling a method "greedy" doesn't make it O(N).
+- **Mixing fractional and 0/1 knapsack** — fractional admits the ratio-greedy proof; 0/1 does not. Items 0/1 with `(w=1, v=2), (w=2, v=3), (w=3, v=4)` and capacity 4 is the classic counterexample.
+- **Forgetting tie-breaking** — when two intervals have the same finish time, the greedy can still be correct but the *count of distinct optimal solutions* may not be. Make tie-breaking deterministic if reproducibility matters.
+
+</details>
+
+## Reference: how to run a topic file
+
+<details>
+<summary>Java / Python / C++ / Rust / Web one-liners</summary>
+
 
 From the week's directory:
 
@@ -41,36 +120,10 @@ open web/<file>.html   # macOS
 xdg-open web/<file>.html   # Linux
 ```
 
-## Topic roadmap
-
-- **1. GreedyAlgorithms**
-
-## Tradeoff Matrix
-
-Flagship topic: Greedy algorithms (activity selection, fractional knapsack, Huffman).
-
-| Approach (interval scheduling) | Time | Space | Code complexity | When to prefer |
-|----------|------|-------|-----------------|----------------|
-| Brute force enumerate subsets | O(2ⁿ) | O(n) | Low | n ≤ 20, oracle for correctness |
-| DP on sorted intervals | O(N log N) | O(N) | Medium | Weighted interval scheduling |
-| Greedy by earliest finish time | O(N log N) | O(1) extra | Low | Unweighted activity selection — provably optimal |
-| Greedy by earliest start time | O(N log N) | O(1) | Low | **Wrong** for activity selection — counterexample exists |
-
-| Approach (knapsack) | Time | Space | When to prefer |
-|----------|------|-------|----------------|
-| Greedy by value/weight ratio | O(N log N) | O(1) | Fractional knapsack — optimal |
-| Greedy by ratio (0/1 version) | O(N log N) | O(1) | **Heuristic only** — can be arbitrarily bad |
-| DP | O(N·W) | O(W) | 0/1 knapsack — correct |
-
-## Anti-patterns to avoid
-
-- **Reaching for greedy because the problem "feels easy"** — greedy is correct only when the problem has the *exchange* / *matroid* property. Always sketch a counterexample attempt before committing.
-- **Sorting by the wrong key** — interval scheduling needs finish time, not start time or duration. The choice of key is the entire algorithm; getting it wrong yields a plausible-looking algorithm that fails on adversarial inputs.
-- **Confusing greedy correctness with greedy efficiency** — even a correct greedy strategy needs O(N log N) sorting; calling a method "greedy" doesn't make it O(N).
-- **Mixing fractional and 0/1 knapsack** — fractional admits the ratio-greedy proof; 0/1 does not. Items 0/1 with `(w=1, v=2), (w=2, v=3), (w=3, v=4)` and capacity 4 is the classic counterexample.
-- **Forgetting tie-breaking** — when two intervals have the same finish time, the greedy can still be correct but the *count of distinct optimal solutions* may not be. Make tie-breaking deterministic if reproducibility matters.
+</details>
 
 ## Reflection prompts
+
 
 - Which topic this week was hardest, and what made it hard?
 - Was there a pattern you didn't recognize and had to be told about? Which one?

--- a/Week 2/README.md
+++ b/Week 2/README.md
@@ -1,10 +1,34 @@
-# Week 2
+# Week 2 — Control Flow
 
-> Self-check: `./scripts/journey quiz 2` — run the mastery checkpoints for this week.
+> Self-check: `./scripts/journey quiz 2`  |  Next session: `./scripts/journey next`
 
-Each topic is implemented in all five languages: **Java, Python, C++, Rust, and Web (HTML/JS)**. The Java track is the primary detailed walkthrough; the others mirror it with idiomatic constructs.
+## Today's session (~30 min)
 
-## Topic index
+1. **Read & run** (15 min) — Walk through the python files in order: `1.*.py`, `2.*.py`, ... — actually run them.
+2. **Type along** (10 min) — Re-type 3 of them from scratch in `workbook/week_02/attempts/`. Don't copy-paste.
+3. **Self-check** (5 min) — `./scripts/journey quiz 2`
+
+Primary language: Python. Compare implementations in `java/`, `cpp/`, `rust/` to see how the same syntax looks across languages.
+
+---
+
+## Topic overview
+
+This week covers **Control Flow**. You'll touch: Data Types review, If else, Find Character Case, While Loop, Infinite Loop, Fahrenheit to Celsius Table. The flagship algorithm/concept for the week is implemented in all five languages, and the Python file listed in Today's session is the canonical walkthrough.
+
+## Related materials
+
+| Resource | Use it when |
+|----------|-------------|
+| [`problems.md`](problems.md) | You want extra practice with company-tagged problems |
+
+## Reference: per-language topic index
+
+<details>
+<summary>All implementations (Java / Python / C++ / Rust / Web)</summary>
+
+**Topic index**
+
 
 | # | Topic | Java | Python | C++ | Rust | Web |
 |---|-------|------|--------|-----|------|-----|
@@ -20,7 +44,8 @@ Each topic is implemented in all five languages: **Java, Python, C++, Rust, and 
 | 10 | Factors | `java/10.Factors.java` | `python/10.factors.py` | `cpp/10.factors.cpp` | `rust/s10_factors.rs` | `web/10.factors.html` |
 | 11 | Find Power | `java/11.Find_Power.java` | `python/11.find_power.py` | `cpp/11.find_power.cpp` | `rust/s11_find_power.rs` | `web/11.find_power.html` |
 
-## Survey companions
+**Survey companions**
+
 
 Cross-cutting files that summarize the week or provide an interactive overview:
 
@@ -29,7 +54,59 @@ Cross-cutting files that summarize the week or provide an interactive overview:
 | Control Flow | — | `python/control_flow.py` | `cpp/control_flow.cpp` | `rust/control_flow.rs` | — |
 | Interactive index | — | — | — | — | `web/index.html` |
 
-## How to run a topic file
+**Topic roadmap**
+
+
+- **1. Data Types review**
+- **2. If else**
+- **3. Find Character Case**
+- **4. While Loop**
+- **5. Infinite Loop**
+- **6. Fahrenheit to Celsius Table**
+- **7. Total Salary**
+- **8. Multiplication Table**
+- **9. Sum of Even Odd**
+- **10. Factors**
+- **11. Find Power**
+
+</details>
+
+## Reference: tradeoff matrix
+
+<details>
+<summary>Approach x Time x Space x When-to-prefer</summary>
+
+
+Flagship topic: computing `a^b` (Find_Power).
+
+| Approach | Time | Space | Code complexity | When to prefer |
+|----------|------|-------|-----------------|----------------|
+| Repeated multiplication (`for i in 1..b`) | O(b) | O(1) | Low | Tiny exponents, learning loops |
+| `Math.pow(a, b)` | O(1) amortized | O(1) | Lowest | When `double` precision is acceptable |
+| Fast exponentiation (binary) | O(log b) | O(1) iterative / O(log b) recursive | Medium | Large `b`, modular exponentiation |
+| Lookup table | O(1) | O(range) | Low | Fixed small domain (e.g. powers of 2 up to 30) |
+
+</details>
+
+## Reference: anti-patterns to avoid
+
+<details>
+<summary>Common mistakes specific to this week's topic</summary>
+
+
+- **Using `Math.pow` for integer answers** — it returns `double`, and `(int) Math.pow(10, 18)` will give you a wrong, off-by-a-few value because doubles only carry ~15 significant digits. Roll your own loop or use `BigInteger.pow`.
+- **Infinite `while` loops because the update is missing or wrong-signed** — `while (n > 0)` with `n--` works; `while (n > 0)` with `n++` runs forever. Always read your loop body and ask "does this make progress toward the exit condition?".
+- **Off-by-one in `for (int i = 0; i <= n; i++)` vs `i < n`** — running one iteration too many is the single most common arithmetic bug. Decide whether `n` is inclusive or exclusive *before* you write the loop.
+- **Using `if (x = 0)` instead of `==`** — Java will reject this for booleans but it still trips C-trained brains. Read the condition aloud: "if x equals zero", not "if x is zero".
+- **Treating `char` as a string** — `'A'` is not `"A"`. They behave differently in concatenation and switch statements.
+
+</details>
+
+## Reference: how to run a topic file
+
+<details>
+<summary>Java / Python / C++ / Rust / Web one-liners</summary>
+
 
 From the week's directory:
 
@@ -51,40 +128,10 @@ open web/<file>.html   # macOS
 xdg-open web/<file>.html   # Linux
 ```
 
-## Topic roadmap
-
-- **1. Data Types review**
-- **2. If else**
-- **3. Find Character Case**
-- **4. While Loop**
-- **5. Infinite Loop**
-- **6. Fahrenheit to Celsius Table**
-- **7. Total Salary**
-- **8. Multiplication Table**
-- **9. Sum of Even Odd**
-- **10. Factors**
-- **11. Find Power**
-
-## Tradeoff Matrix
-
-Flagship topic: computing `a^b` (Find_Power).
-
-| Approach | Time | Space | Code complexity | When to prefer |
-|----------|------|-------|-----------------|----------------|
-| Repeated multiplication (`for i in 1..b`) | O(b) | O(1) | Low | Tiny exponents, learning loops |
-| `Math.pow(a, b)` | O(1) amortized | O(1) | Lowest | When `double` precision is acceptable |
-| Fast exponentiation (binary) | O(log b) | O(1) iterative / O(log b) recursive | Medium | Large `b`, modular exponentiation |
-| Lookup table | O(1) | O(range) | Low | Fixed small domain (e.g. powers of 2 up to 30) |
-
-## Anti-patterns to avoid
-
-- **Using `Math.pow` for integer answers** — it returns `double`, and `(int) Math.pow(10, 18)` will give you a wrong, off-by-a-few value because doubles only carry ~15 significant digits. Roll your own loop or use `BigInteger.pow`.
-- **Infinite `while` loops because the update is missing or wrong-signed** — `while (n > 0)` with `n--` works; `while (n > 0)` with `n++` runs forever. Always read your loop body and ask "does this make progress toward the exit condition?".
-- **Off-by-one in `for (int i = 0; i <= n; i++)` vs `i < n`** — running one iteration too many is the single most common arithmetic bug. Decide whether `n` is inclusive or exclusive *before* you write the loop.
-- **Using `if (x = 0)` instead of `==`** — Java will reject this for booleans but it still trips C-trained brains. Read the condition aloud: "if x equals zero", not "if x is zero".
-- **Treating `char` as a string** — `'A'` is not `"A"`. They behave differently in concatenation and switch statements.
+</details>
 
 ## Reflection prompts
+
 
 - Which topic this week was hardest, and what made it hard?
 - Was there a pattern you didn't recognize and had to be told about? Which one?

--- a/Week 20/README.md
+++ b/Week 20/README.md
@@ -1,16 +1,47 @@
-# Week 20
+# Week 20 — Backtracking
 
-> Self-check: `./scripts/journey quiz 20` — run the mastery checkpoints for this week.
+> Self-check: `./scripts/journey quiz 20`  |  Next session: `./scripts/journey next`
 
-Each topic is implemented in all five languages: **Java, Python, C++, Rust, and Web (HTML/JS)**. The Java track is the primary detailed walkthrough; the others mirror it with idiomatic constructs.
+## Today's session (~45 min)
 
-## Topic index
+1. **Concept** (10 min) — Read [`python/1.Backtracking.py`](python/1.Backtracking.py) (CONCEPT + KEY POINTS blocks).
+2. **Recognize the pattern** (5 min) — Try drills 1-5 in [`patterns.md`](patterns.md) cold.
+3. **Implement from spec** (20 min) — Pick Challenge 1 from [`challenges.md`](challenges.md). Code it in `workbook/week_20/attempts/`.
+4. **Verify YOUR code** (5 min) — `./scripts/journey verify n_queens_count workbook/week_20/attempts/<your-file>.py`
+5. **Mastery quiz** (5 min) — `./scripts/journey quiz 20`
+
+If you got stuck: open [`python/1.Backtracking.py`](python/1.Backtracking.py) and diff against your attempt.
+If you finish early: drills 6-10 in `patterns.md`, or Challenge 2.
+
+**Primary language: Python.** Want to compare implementations? See the per-language table below.
+
+---
+
+## Topic overview
+
+This week covers **Backtracking**. You'll touch: Backtracking. The flagship algorithm/concept for the week is implemented in all five languages, and the Python file listed in Today's session is the canonical walkthrough.
+
+## Related materials
+
+| Resource | Use it when |
+|----------|-------------|
+| Capstone: [`capstones/phase_4_maze_solver.md`](../capstones/phase_4_maze_solver.md) | Phase 4 capstone — apply what you learned in weeks 16-20 |
+| [`problems.md`](problems.md) | You want extra practice with company-tagged problems |
+
+## Reference: per-language topic index
+
+<details>
+<summary>All implementations (Java / Python / C++ / Rust / Web)</summary>
+
+**Topic index**
+
 
 | # | Topic | Java | Python | C++ | Rust | Web |
 |---|-------|------|--------|-----|------|-----|
 | 1 | Backtracking | `java/1.Backtracking.java` | `python/1.Backtracking.py` | `cpp/1.Backtracking.cpp` | `rust/s01_Backtracking.rs` | `web/1.Backtracking.html` |
 
-## Survey companions
+**Survey companions**
+
 
 Cross-cutting files that summarize the week or provide an interactive overview:
 
@@ -19,7 +50,55 @@ Cross-cutting files that summarize the week or provide an interactive overview:
 | Backtracking | — | `python/backtracking.py` | `cpp/backtracking.cpp` | `rust/backtracking.rs` | — |
 | Interactive index | — | — | — | — | `web/index.html` |
 
-## How to run a topic file
+**Topic roadmap**
+
+
+- **1. Backtracking**
+
+</details>
+
+## Reference: tradeoff matrix
+
+<details>
+<summary>Approach x Time x Space x When-to-prefer</summary>
+
+
+Flagship topic: Backtracking (N-Queens, permutations, subsets, Sudoku).
+
+| Approach (N-Queens) | Time | Space | Code complexity | When to prefer |
+|----------|------|-------|-----------------|----------------|
+| Brute force all placements | O(Nⁿ) | O(N) | Low | N ≤ 4 |
+| Permutations of columns | O(N!) | O(N) | Medium | Removes one type of conflict for free |
+| Backtracking + diagonal/column sets | O(N!) but pruned heavily | O(N) | Medium | Default; solves N=20 in seconds |
+| Bitmask backtracking | O(N!) pruned | O(N) | Medium | Same asymptotics, much faster constants |
+| Branch and bound with constraint propagation | varies | varies | High | Solving Sudoku / ASP-style problems |
+
+| Approach (subsets) | Time | Space | When to prefer |
+|----------|------|-------|----------------|
+| Recursion (include/exclude) | O(2ⁿ · n) | O(n) | Default |
+| Iterative bitmask enumeration | O(2ⁿ · n) | O(1) extra | Branch-free, easy to parallelize |
+
+</details>
+
+## Reference: anti-patterns to avoid
+
+<details>
+<summary>Common mistakes specific to this week's topic</summary>
+
+
+- **Forgetting to undo the change after the recursive call** — backtracking *requires* you to restore state so the caller sees the original input. Mutating without undoing turns a search tree into spaghetti.
+- **Adding `new ArrayList<>(current)` to the result on every leaf** — correct, but if you forget the copy and add `current` directly, all your results point to the same (final, empty) list. Copy the snapshot.
+- **Pruning incorrectly so you miss valid solutions** — pruning must be a *necessary* condition for failure. "It probably won't work" is not enough; the proof has to be airtight.
+- **Building the board as `String` and concatenating** — turns each push into an allocation. Use `char[][]` and mutate in place, undoing on backtrack.
+- **Choosing the next variable arbitrarily** — for Sudoku-like problems, picking the most-constrained cell (MRV heuristic) reduces the search space by orders of magnitude. Picking row-major order is naive but acceptable for learning.
+
+</details>
+
+## Reference: how to run a topic file
+
+<details>
+<summary>Java / Python / C++ / Rust / Web one-liners</summary>
+
 
 From the week's directory:
 
@@ -41,36 +120,10 @@ open web/<file>.html   # macOS
 xdg-open web/<file>.html   # Linux
 ```
 
-## Topic roadmap
-
-- **1. Backtracking**
-
-## Tradeoff Matrix
-
-Flagship topic: Backtracking (N-Queens, permutations, subsets, Sudoku).
-
-| Approach (N-Queens) | Time | Space | Code complexity | When to prefer |
-|----------|------|-------|-----------------|----------------|
-| Brute force all placements | O(Nⁿ) | O(N) | Low | N ≤ 4 |
-| Permutations of columns | O(N!) | O(N) | Medium | Removes one type of conflict for free |
-| Backtracking + diagonal/column sets | O(N!) but pruned heavily | O(N) | Medium | Default; solves N=20 in seconds |
-| Bitmask backtracking | O(N!) pruned | O(N) | Medium | Same asymptotics, much faster constants |
-| Branch and bound with constraint propagation | varies | varies | High | Solving Sudoku / ASP-style problems |
-
-| Approach (subsets) | Time | Space | When to prefer |
-|----------|------|-------|----------------|
-| Recursion (include/exclude) | O(2ⁿ · n) | O(n) | Default |
-| Iterative bitmask enumeration | O(2ⁿ · n) | O(1) extra | Branch-free, easy to parallelize |
-
-## Anti-patterns to avoid
-
-- **Forgetting to undo the change after the recursive call** — backtracking *requires* you to restore state so the caller sees the original input. Mutating without undoing turns a search tree into spaghetti.
-- **Adding `new ArrayList<>(current)` to the result on every leaf** — correct, but if you forget the copy and add `current` directly, all your results point to the same (final, empty) list. Copy the snapshot.
-- **Pruning incorrectly so you miss valid solutions** — pruning must be a *necessary* condition for failure. "It probably won't work" is not enough; the proof has to be airtight.
-- **Building the board as `String` and concatenating** — turns each push into an allocation. Use `char[][]` and mutate in place, undoing on backtrack.
-- **Choosing the next variable arbitrarily** — for Sudoku-like problems, picking the most-constrained cell (MRV heuristic) reduces the search space by orders of magnitude. Picking row-major order is naive but acceptable for learning.
+</details>
 
 ## Reflection prompts
+
 
 - Which topic this week was hardest, and what made it hard?
 - Was there a pattern you didn't recognize and had to be told about? Which one?

--- a/Week 21/README.md
+++ b/Week 21/README.md
@@ -1,17 +1,48 @@
-# Week 21
+# Week 21 — Advanced Trees
 
-> Self-check: `./scripts/journey quiz 21` — run the mastery checkpoints for this week.
+> Self-check: `./scripts/journey quiz 21`  |  Next session: `./scripts/journey next`
 
-Each topic is implemented in all five languages: **Java, Python, C++, Rust, and Web (HTML/JS)**. The Java track is the primary detailed walkthrough; the others mirror it with idiomatic constructs.
+## Today's session (~45 min)
 
-## Topic index
+1. **Concept** (10 min) — Read [`python/1.SegmentTreeAndBIT.py`](python/1.SegmentTreeAndBIT.py) (CONCEPT + KEY POINTS blocks).
+2. **Recognize the pattern** (5 min) — Try drills 1-5 in [`patterns.md`](patterns.md) cold.
+3. **Implement from spec** (20 min) — Pick Challenge 1 from [`challenges.md`](challenges.md). Code it in `workbook/week_21/attempts/`.
+4. **Verify YOUR code** (5 min) — `./scripts/journey verify avl_balance_factor workbook/week_21/attempts/<your-file>.py`
+5. **Mastery quiz** (5 min) — `./scripts/journey quiz 21`
+
+If you got stuck: open [`python/1.SegmentTreeAndBIT.py`](python/1.SegmentTreeAndBIT.py) and diff against your attempt.
+If you finish early: drills 6-10 in `patterns.md`, or Challenge 2.
+
+**Primary language: Python.** Want to compare implementations? See the per-language table below.
+
+---
+
+## Topic overview
+
+This week covers **Advanced Trees**. You'll touch: SegmentTreeAndBIT, Trie. The flagship algorithm/concept for the week is implemented in all five languages, and the Python file listed in Today's session is the canonical walkthrough.
+
+## Related materials
+
+| Resource | Use it when |
+|----------|-------------|
+| Visualization: [`viz/segment_tree.html`](../viz/segment_tree.html) | You want to SEE the segment tree update and query |
+| [`problems.md`](problems.md) | You want extra practice with company-tagged problems |
+
+## Reference: per-language topic index
+
+<details>
+<summary>All implementations (Java / Python / C++ / Rust / Web)</summary>
+
+**Topic index**
+
 
 | # | Topic | Java | Python | C++ | Rust | Web |
 |---|-------|------|--------|-----|------|-----|
 | 1 | SegmentTreeAndBIT | `java/1.SegmentTreeAndBIT.java` | `python/1.SegmentTreeAndBIT.py` | `cpp/1.SegmentTreeAndBIT.cpp` | `rust/s01_SegmentTreeAndBIT.rs` | `web/1.SegmentTreeAndBIT.html` |
 | 2 | Trie | `java/2.Trie.java` | `python/2.Trie.py` | `cpp/2.Trie.cpp` | `rust/s02_Trie.rs` | `web/2.Trie.html` |
 
-## Survey companions
+**Survey companions**
+
 
 Cross-cutting files that summarize the week or provide an interactive overview:
 
@@ -20,7 +51,57 @@ Cross-cutting files that summarize the week or provide an interactive overview:
 | Advanced Trees | — | `python/advanced_trees.py` | `cpp/advanced_trees.cpp` | `rust/advanced_trees.rs` | — |
 | Interactive index | — | — | — | — | `web/index.html` |
 
-## How to run a topic file
+**Topic roadmap**
+
+
+- **1. SegmentTreeAndBIT**
+- **2. Trie**
+
+</details>
+
+## Reference: tradeoff matrix
+
+<details>
+<summary>Approach x Time x Space x When-to-prefer</summary>
+
+
+Flagship topic: Range queries (Segment Tree / BIT) and prefix structures (Trie).
+
+| Approach (range sum / point update) | Build | Update | Query | When to prefer |
+|----------|------|--------|-------|----------------|
+| Naive array | O(N) | O(1) | O(N) | Tiny inputs |
+| Prefix sum array | O(N) | O(N) | O(1) | Read-mostly, updates rare |
+| Binary Indexed Tree (Fenwick) | O(N log N) | O(log N) | O(log N) | Simpler code; sum/XOR-style queries |
+| Segment tree | O(N) | O(log N) | O(log N) | General; supports min/max/gcd, lazy propagation |
+| Sqrt decomposition | O(N) | O(√N) | O(√N) | Off-line and easier to reason about |
+
+| Approach (Trie use case) | Time per op | Space | When to prefer |
+|----------|------|-------|----------------|
+| HashSet of strings | O(L) avg | O(total chars) | When you only need exact membership |
+| Trie | O(L) | O(total chars × Σ) | Prefix queries, autocomplete, XOR-max (binary trie) |
+| Suffix automaton / array | O(N) build | O(N) | All-substrings queries |
+
+</details>
+
+## Reference: anti-patterns to avoid
+
+<details>
+<summary>Common mistakes specific to this week's topic</summary>
+
+
+- **Building a segment tree on 2N size when you need 4N** — for arbitrary N (not a power of 2), allocate `4 * N` to be safe. Allocating `2 * N` segfaults on odd N.
+- **Forgetting lazy propagation on range updates** — without lazy, a range update is O(N log N), defeating the point. Push the pending update down before any read or recursion into children.
+- **BIT 1-indexed off-by-one** — Fenwick trees are easiest 1-indexed. Mixing 0-indexed input with 1-indexed BIT internals is a common bug; pick one convention and translate at the boundary.
+- **Trie children as `HashMap<Character, Node>` when you only have 26 letters** — fixed-size array `Node[26]` is faster and uses less memory. Map is only worth it for large/sparse alphabets.
+- **Storing `isEnd` only at leaves** — once a longer word is inserted, the shorter word's endpoint isn't a leaf anymore. The `isEnd` flag must live on the node, regardless of whether it's a leaf.
+
+</details>
+
+## Reference: how to run a topic file
+
+<details>
+<summary>Java / Python / C++ / Rust / Web one-liners</summary>
+
 
 From the week's directory:
 
@@ -42,38 +123,10 @@ open web/<file>.html   # macOS
 xdg-open web/<file>.html   # Linux
 ```
 
-## Topic roadmap
-
-- **1. SegmentTreeAndBIT**
-- **2. Trie**
-
-## Tradeoff Matrix
-
-Flagship topic: Range queries (Segment Tree / BIT) and prefix structures (Trie).
-
-| Approach (range sum / point update) | Build | Update | Query | When to prefer |
-|----------|------|--------|-------|----------------|
-| Naive array | O(N) | O(1) | O(N) | Tiny inputs |
-| Prefix sum array | O(N) | O(N) | O(1) | Read-mostly, updates rare |
-| Binary Indexed Tree (Fenwick) | O(N log N) | O(log N) | O(log N) | Simpler code; sum/XOR-style queries |
-| Segment tree | O(N) | O(log N) | O(log N) | General; supports min/max/gcd, lazy propagation |
-| Sqrt decomposition | O(N) | O(√N) | O(√N) | Off-line and easier to reason about |
-
-| Approach (Trie use case) | Time per op | Space | When to prefer |
-|----------|------|-------|----------------|
-| HashSet of strings | O(L) avg | O(total chars) | When you only need exact membership |
-| Trie | O(L) | O(total chars × Σ) | Prefix queries, autocomplete, XOR-max (binary trie) |
-| Suffix automaton / array | O(N) build | O(N) | All-substrings queries |
-
-## Anti-patterns to avoid
-
-- **Building a segment tree on 2N size when you need 4N** — for arbitrary N (not a power of 2), allocate `4 * N` to be safe. Allocating `2 * N` segfaults on odd N.
-- **Forgetting lazy propagation on range updates** — without lazy, a range update is O(N log N), defeating the point. Push the pending update down before any read or recursion into children.
-- **BIT 1-indexed off-by-one** — Fenwick trees are easiest 1-indexed. Mixing 0-indexed input with 1-indexed BIT internals is a common bug; pick one convention and translate at the boundary.
-- **Trie children as `HashMap<Character, Node>` when you only have 26 letters** — fixed-size array `Node[26]` is faster and uses less memory. Map is only worth it for large/sparse alphabets.
-- **Storing `isEnd` only at leaves** — once a longer word is inserted, the shorter word's endpoint isn't a leaf anymore. The `isEnd` flag must live on the node, regardless of whether it's a leaf.
+</details>
 
 ## Reflection prompts
+
 
 - Which topic this week was hardest, and what made it hard?
 - Was there a pattern you didn't recognize and had to be told about? Which one?

--- a/Week 22/README.md
+++ b/Week 22/README.md
@@ -1,17 +1,49 @@
-# Week 22
+# Week 22 — Advanced Graph Algorithms
 
-> Self-check: `./scripts/journey quiz 22` — run the mastery checkpoints for this week.
+> Self-check: `./scripts/journey quiz 22`  |  Next session: `./scripts/journey next`
 
-Each topic is implemented in all five languages: **Java, Python, C++, Rust, and Web (HTML/JS)**. The Java track is the primary detailed walkthrough; the others mirror it with idiomatic constructs.
+## Today's session (~45 min)
 
-## Topic index
+1. **Concept** (10 min) — Read [`python/1.ShortestPaths.py`](python/1.ShortestPaths.py) (CONCEPT + KEY POINTS blocks).
+2. **Recognize the pattern** (5 min) — Try drills 1-5 in [`patterns.md`](patterns.md) cold.
+3. **Implement from spec** (20 min) — Pick Challenge 1 from [`challenges.md`](challenges.md). Code it in `workbook/week_22/attempts/`.
+4. **Verify YOUR code** (5 min) — `./scripts/journey verify dijkstra_shortest_path workbook/week_22/attempts/<your-file>.py`
+5. **Mastery quiz** (5 min) — `./scripts/journey quiz 22`
+
+If you got stuck: open [`python/1.ShortestPaths.py`](python/1.ShortestPaths.py) and diff against your attempt.
+If you finish early: drills 6-10 in `patterns.md`, or Challenge 2.
+
+**Primary language: Python.** Want to compare implementations? See the per-language table below.
+
+---
+
+## Topic overview
+
+This week covers **Advanced Graph Algorithms**. You'll touch: ShortestPaths, MinimumSpanningTree. The flagship algorithm/concept for the week is implemented in all five languages, and the Python file listed in Today's session is the canonical walkthrough.
+
+## Related materials
+
+| Resource | Use it when |
+|----------|-------------|
+| Visualization: [`viz/dijkstra.html`](../viz/dijkstra.html) | You want to SEE Dijkstra relax edges step by step |
+| Mock interview: [`mock_interviews/04_word_ladder_bfs.md`](../mock_interviews/04_word_ladder_bfs.md) | Graph / shortest-path problems discussed conversationally |
+| [`problems.md`](problems.md) | You want extra practice with company-tagged problems |
+
+## Reference: per-language topic index
+
+<details>
+<summary>All implementations (Java / Python / C++ / Rust / Web)</summary>
+
+**Topic index**
+
 
 | # | Topic | Java | Python | C++ | Rust | Web |
 |---|-------|------|--------|-----|------|-----|
 | 1 | ShortestPaths | `java/1.ShortestPaths.java` | `python/1.ShortestPaths.py` | `cpp/1.ShortestPaths.cpp` | `rust/s01_ShortestPaths.rs` | `web/1.ShortestPaths.html` |
 | 2 | MinimumSpanningTree | `java/2.MinimumSpanningTree.java` | `python/2.MinimumSpanningTree.py` | `cpp/2.MinimumSpanningTree.cpp` | `rust/s02_MinimumSpanningTree.rs` | `web/2.MinimumSpanningTree.html` |
 
-## Survey companions
+**Survey companions**
+
 
 Cross-cutting files that summarize the week or provide an interactive overview:
 
@@ -20,7 +52,59 @@ Cross-cutting files that summarize the week or provide an interactive overview:
 | Advanced Graphs | — | `python/advanced_graphs.py` | `cpp/advanced_graphs.cpp` | `rust/advanced_graphs.rs` | — |
 | Interactive index | — | — | — | — | `web/index.html` |
 
-## How to run a topic file
+**Topic roadmap**
+
+
+- **1. ShortestPaths**
+- **2. MinimumSpanningTree**
+
+</details>
+
+## Reference: tradeoff matrix
+
+<details>
+<summary>Approach x Time x Space x When-to-prefer</summary>
+
+
+Flagship topic: Shortest paths and Minimum Spanning Trees.
+
+| Approach (shortest path) | Time | Space | Restrictions | When to prefer |
+|----------|------|-------|--------------|----------------|
+| BFS | O(V + E) | O(V) | Unweighted / unit weights | Unweighted SSSP |
+| Dijkstra (binary heap) | O((V + E) log V) | O(V) | Non-negative weights | Default for weighted SSSP |
+| Dijkstra (Fibonacci heap) | O(E + V log V) | O(V) | Non-negative weights | Theory; rarely worth the constants in practice |
+| Bellman–Ford | O(V·E) | O(V) | Detects negative cycles | Negative weights, or you need cycle detection |
+| SPFA (queue-based BF) | O(V·E) worst, fast avg | O(V) | Same as BF | Practical Bellman–Ford on sparse graphs |
+| Floyd–Warshall | O(V³) | O(V²) | All pairs | Dense, V ≤ ~400 |
+| 0-1 BFS | O(V + E) | O(V) | Weights in {0, 1} | Faster than Dijkstra for binary weights |
+
+| Approach (MST) | Time | Space | When to prefer |
+|----------|------|-------|----------------|
+| Kruskal (Union-Find) | O(E log E) | O(V) | Sparse graphs, edge list available |
+| Prim (binary heap) | O((V+E) log V) | O(V) | Dense graphs, adjacency list |
+| Borůvka | O(E log V) | O(V) | Parallelizable, theoretical interest |
+
+</details>
+
+## Reference: anti-patterns to avoid
+
+<details>
+<summary>Common mistakes specific to this week's topic</summary>
+
+
+- **Running Dijkstra on a graph with negative edges** — relaxation is no longer monotone; popped nodes might still be reducible. Use Bellman–Ford, or transform with Johnson's algorithm.
+- **Reusing a `dist[]` array without re-initializing to `+∞`** — leftover values from a previous run look like reachable nodes. Reset (or use a `Map`) every call.
+- **Pushing duplicates into the heap and forgetting to skip stale entries** — when you find a shorter path, the old (longer) heap entry is still there. Either implement decrease-key, or check `if (d > dist[u]) continue;` on each pop.
+- **Kruskal without Union-Find** — cycle detection via DFS on every edge is O(V·E). Union-Find with path compression turns it into nearly O(α(V)).
+- **Floyd–Warshall with the loops in the wrong order** — the `k` (intermediate) loop must be the *outermost*. Putting it inside breaks the dynamic-programming invariant and gives wrong answers on most graphs.
+
+</details>
+
+## Reference: how to run a topic file
+
+<details>
+<summary>Java / Python / C++ / Rust / Web one-liners</summary>
+
 
 From the week's directory:
 
@@ -42,40 +126,10 @@ open web/<file>.html   # macOS
 xdg-open web/<file>.html   # Linux
 ```
 
-## Topic roadmap
-
-- **1. ShortestPaths**
-- **2. MinimumSpanningTree**
-
-## Tradeoff Matrix
-
-Flagship topic: Shortest paths and Minimum Spanning Trees.
-
-| Approach (shortest path) | Time | Space | Restrictions | When to prefer |
-|----------|------|-------|--------------|----------------|
-| BFS | O(V + E) | O(V) | Unweighted / unit weights | Unweighted SSSP |
-| Dijkstra (binary heap) | O((V + E) log V) | O(V) | Non-negative weights | Default for weighted SSSP |
-| Dijkstra (Fibonacci heap) | O(E + V log V) | O(V) | Non-negative weights | Theory; rarely worth the constants in practice |
-| Bellman–Ford | O(V·E) | O(V) | Detects negative cycles | Negative weights, or you need cycle detection |
-| SPFA (queue-based BF) | O(V·E) worst, fast avg | O(V) | Same as BF | Practical Bellman–Ford on sparse graphs |
-| Floyd–Warshall | O(V³) | O(V²) | All pairs | Dense, V ≤ ~400 |
-| 0-1 BFS | O(V + E) | O(V) | Weights in {0, 1} | Faster than Dijkstra for binary weights |
-
-| Approach (MST) | Time | Space | When to prefer |
-|----------|------|-------|----------------|
-| Kruskal (Union-Find) | O(E log E) | O(V) | Sparse graphs, edge list available |
-| Prim (binary heap) | O((V+E) log V) | O(V) | Dense graphs, adjacency list |
-| Borůvka | O(E log V) | O(V) | Parallelizable, theoretical interest |
-
-## Anti-patterns to avoid
-
-- **Running Dijkstra on a graph with negative edges** — relaxation is no longer monotone; popped nodes might still be reducible. Use Bellman–Ford, or transform with Johnson's algorithm.
-- **Reusing a `dist[]` array without re-initializing to `+∞`** — leftover values from a previous run look like reachable nodes. Reset (or use a `Map`) every call.
-- **Pushing duplicates into the heap and forgetting to skip stale entries** — when you find a shorter path, the old (longer) heap entry is still there. Either implement decrease-key, or check `if (d > dist[u]) continue;` on each pop.
-- **Kruskal without Union-Find** — cycle detection via DFS on every edge is O(V·E). Union-Find with path compression turns it into nearly O(α(V)).
-- **Floyd–Warshall with the loops in the wrong order** — the `k` (intermediate) loop must be the *outermost*. Putting it inside breaks the dynamic-programming invariant and gives wrong answers on most graphs.
+</details>
 
 ## Reflection prompts
+
 
 - Which topic this week was hardest, and what made it hard?
 - Was there a pattern you didn't recognize and had to be told about? Which one?

--- a/Week 23/README.md
+++ b/Week 23/README.md
@@ -1,16 +1,47 @@
-# Week 23
+# Week 23 — Advanced Dynamic Programming
 
-> Self-check: `./scripts/journey quiz 23` — run the mastery checkpoints for this week.
+> Self-check: `./scripts/journey quiz 23`  |  Next session: `./scripts/journey next`
 
-Each topic is implemented in all five languages: **Java, Python, C++, Rust, and Web (HTML/JS)**. The Java track is the primary detailed walkthrough; the others mirror it with idiomatic constructs.
+## Today's session (~45 min)
 
-## Topic index
+1. **Concept** (10 min) — Read [`python/1.AdvancedDP.py`](python/1.AdvancedDP.py) (CONCEPT + KEY POINTS blocks).
+2. **Recognize the pattern** (5 min) — Try drills 1-5 in [`patterns.md`](patterns.md) cold.
+3. **Implement from spec** (20 min) — Pick Challenge 1 from [`challenges.md`](challenges.md). Code it in `workbook/week_23/attempts/`.
+4. **Verify YOUR code** (5 min) — `./scripts/journey verify bitmask_dp_state_count workbook/week_23/attempts/<your-file>.py`
+5. **Mastery quiz** (5 min) — `./scripts/journey quiz 23`
+
+If you got stuck: open [`python/1.AdvancedDP.py`](python/1.AdvancedDP.py) and diff against your attempt.
+If you finish early: drills 6-10 in `patterns.md`, or Challenge 2.
+
+**Primary language: Python.** Want to compare implementations? See the per-language table below.
+
+---
+
+## Topic overview
+
+This week covers **Advanced Dynamic Programming**. You'll touch: AdvancedDP. The flagship algorithm/concept for the week is implemented in all five languages, and the Python file listed in Today's session is the canonical walkthrough.
+
+## Related materials
+
+| Resource | Use it when |
+|----------|-------------|
+| Mock interview: [`mock_interviews/05_dp_house_robber_iii.md`](../mock_interviews/05_dp_house_robber_iii.md) | Advanced DP discussed conversationally |
+| [`problems.md`](problems.md) | You want extra practice with company-tagged problems |
+
+## Reference: per-language topic index
+
+<details>
+<summary>All implementations (Java / Python / C++ / Rust / Web)</summary>
+
+**Topic index**
+
 
 | # | Topic | Java | Python | C++ | Rust | Web |
 |---|-------|------|--------|-----|------|-----|
 | 1 | AdvancedDP | `java/1.AdvancedDP.java` | `python/1.AdvancedDP.py` | `cpp/1.AdvancedDP.cpp` | `rust/s01_AdvancedDP.rs` | `web/1.AdvancedDP.html` |
 
-## Survey companions
+**Survey companions**
+
 
 Cross-cutting files that summarize the week or provide an interactive overview:
 
@@ -19,33 +50,18 @@ Cross-cutting files that summarize the week or provide an interactive overview:
 | Advanced Dp | — | `python/advanced_dp.py` | `cpp/advanced_dp.cpp` | `rust/advanced_dp.rs` | — |
 | Interactive index | — | — | — | — | `web/index.html` |
 
-## How to run a topic file
+**Topic roadmap**
 
-From the week's directory:
-
-```bash
-# Java
-javac java/<file>.java && java -cp java <ClassName>
-
-# Python
-python3 python/<file>.py
-
-# C++
-g++ -std=c++17 cpp/<file>.cpp -o /tmp/a && /tmp/a
-
-# Rust
-rustc --edition 2021 rust/<file>.rs -o /tmp/a && /tmp/a
-
-# Web — open in a browser
-open web/<file>.html   # macOS
-xdg-open web/<file>.html   # Linux
-```
-
-## Topic roadmap
 
 - **1. AdvancedDP**
 
-## Tradeoff Matrix
+</details>
+
+## Reference: tradeoff matrix
+
+<details>
+<summary>Approach x Time x Space x When-to-prefer</summary>
+
 
 Flagship topic: Advanced DP (bitmask DP, digit DP, DP on trees, DP optimizations).
 
@@ -69,7 +85,13 @@ Flagship topic: Advanced DP (bitmask DP, digit DP, DP on trees, DP optimizations
 | Knuth's optimization | O(N³) → O(N²) | Quadrangle-inequality interval DPs |
 | Aliens trick / parametric search | adds a log factor for one less dim | "exactly k" partition problems |
 
-## Anti-patterns to avoid
+</details>
+
+## Reference: anti-patterns to avoid
+
+<details>
+<summary>Common mistakes specific to this week's topic</summary>
+
 
 - **Bitmask DP without verifying the state space fits** — `2²⁵` states × 25 transitions is fine; `2³⁰` is not. Compute the product before coding.
 - **Iterating subsets the slow way** — to iterate all subsets of a mask, use `for (int s = mask; s > 0; s = (s-1) & mask)`. The naive `for (i in 0..(1<<n))` plus filter is exponentially slower for sum-over-subsets style DPs.
@@ -77,7 +99,38 @@ Flagship topic: Advanced DP (bitmask DP, digit DP, DP on trees, DP optimizations
 - **Rerooting DP that doesn't subtract the child's contribution carefully** — if your aggregate isn't reversible (e.g. min/max instead of sum), rerooting requires keeping top-2 values per node. Treating min/max as sum is the single most common bug here.
 - **Applying CHT without checking the slope ordering** — Convex Hull Trick requires lines to be added in sorted slope order (or you need Li Chao tree). Adding arbitrary lines to a monotonic deque silently corrupts the hull.
 
+</details>
+
+## Reference: how to run a topic file
+
+<details>
+<summary>Java / Python / C++ / Rust / Web one-liners</summary>
+
+
+From the week's directory:
+
+```bash
+# Java
+javac java/<file>.java && java -cp java <ClassName>
+
+# Python
+python3 python/<file>.py
+
+# C++
+g++ -std=c++17 cpp/<file>.cpp -o /tmp/a && /tmp/a
+
+# Rust
+rustc --edition 2021 rust/<file>.rs -o /tmp/a && /tmp/a
+
+# Web — open in a browser
+open web/<file>.html   # macOS
+xdg-open web/<file>.html   # Linux
+```
+
+</details>
+
 ## Reflection prompts
+
 
 - Which topic this week was hardest, and what made it hard?
 - Was there a pattern you didn't recognize and had to be told about? Which one?

--- a/Week 24/README.md
+++ b/Week 24/README.md
@@ -1,17 +1,47 @@
-# Week 24
+# Week 24 — Research-Level Topics
 
-> Self-check: `./scripts/journey quiz 24` — run the mastery checkpoints for this week.
+> Self-check: `./scripts/journey quiz 24`  |  Next session: `./scripts/journey next`
 
-Each topic is implemented in all five languages: **Java, Python, C++, Rust, and Web (HTML/JS)**. The Java track is the primary detailed walkthrough; the others mirror it with idiomatic constructs.
+## Today's session (~45 min)
 
-## Topic index
+1. **Concept** (10 min) — Read [`python/1.ResearchLevelTopics.py`](python/1.ResearchLevelTopics.py) (CONCEPT + KEY POINTS blocks).
+2. **Recognize the pattern** (5 min) — Try drills 1-5 in [`patterns.md`](patterns.md) cold.
+3. **Implement from spec** (20 min) — Pick Challenge 1 from [`challenges.md`](challenges.md). Code it in `workbook/week_24/attempts/`.
+4. **Verify YOUR code** (5 min) — `./scripts/journey verify amortized_methods workbook/week_24/attempts/<your-file>.py`
+5. **Mastery quiz** (5 min) — `./scripts/journey quiz 24`
+
+If you got stuck: open [`python/1.ResearchLevelTopics.py`](python/1.ResearchLevelTopics.py) and diff against your attempt.
+If you finish early: drills 6-10 in `patterns.md`, or Challenge 2.
+
+**Primary language: Python.** Want to compare implementations? See the per-language table below.
+
+---
+
+## Topic overview
+
+This week covers **Research-Level Topics**. You'll touch: ResearchLevelTopics, NPCompletenessAndApproximation. The flagship algorithm/concept for the week is implemented in all five languages, and the Python file listed in Today's session is the canonical walkthrough.
+
+## Related materials
+
+| Resource | Use it when |
+|----------|-------------|
+| [`problems.md`](problems.md) | You want extra practice with company-tagged problems |
+
+## Reference: per-language topic index
+
+<details>
+<summary>All implementations (Java / Python / C++ / Rust / Web)</summary>
+
+**Topic index**
+
 
 | # | Topic | Java | Python | C++ | Rust | Web |
 |---|-------|------|--------|-----|------|-----|
 | 1 | ResearchLevelTopics | `java/1.ResearchLevelTopics.java` | `python/1.ResearchLevelTopics.py` | `cpp/1.ResearchLevelTopics.cpp` | `rust/s01_ResearchLevelTopics.rs` | `web/1.ResearchLevelTopics.html` |
 | 2 | NPCompletenessAndApproximation | `java/2.NPCompletenessAndApproximation.java` | `python/2.NPCompletenessAndApproximation.py` | `cpp/2.NPCompletenessAndApproximation.cpp` | `rust/s02_NPCompletenessAndApproximation.rs` | `web/2.NPCompletenessAndApproximation.html` |
 
-## Survey companions
+**Survey companions**
+
 
 Cross-cutting files that summarize the week or provide an interactive overview:
 
@@ -20,7 +50,59 @@ Cross-cutting files that summarize the week or provide an interactive overview:
 | Research Level | — | `python/research_level.py` | `cpp/research_level.cpp` | `rust/research_level.rs` | — |
 | Interactive index | — | — | — | — | `web/index.html` |
 
-## How to run a topic file
+**Topic roadmap**
+
+
+- **1. ResearchLevelTopics**
+- **2. NPCompletenessAndApproximation**
+
+</details>
+
+## Reference: tradeoff matrix
+
+<details>
+<summary>Approach x Time x Space x When-to-prefer</summary>
+
+
+Flagship topic: NP-completeness and approximation algorithms.
+
+| Approach (NP-hard problem strategies) | Quality | Time | When to prefer |
+|----------|------|------|----------------|
+| Exact exponential (DP, B&B) | Optimal | Exponential | Small inputs (n ≤ 30-50 with good pruning) |
+| Approximation algorithm | Bounded factor (e.g. 2× optimal) | Polynomial | Need a worst-case guarantee |
+| Heuristic / local search | No guarantee, often great | Polynomial | Real-world solvers (SAT, TSP) |
+| Randomized (Las Vegas / Monte Carlo) | Probabilistic guarantee | Polynomial expected | When randomness breaks adversarial inputs |
+| Parameterized / FPT algorithms | Optimal | f(k) · poly(n) | Small "parameter" k even if n is large |
+| ILP solver | Optimal | Black-box exponential | When modeling beats hand-coding |
+
+| Approach (Vertex Cover) | Approximation ratio | Time | When to prefer |
+|----------|------|------|----------------|
+| Greedy by highest degree | log n | O(E log V) | Quick baseline |
+| Pick both endpoints of any uncovered edge | 2 | O(E) | Provable 2-approximation |
+| LP relaxation + rounding | 2 | poly | When you already have an LP solver |
+| Exact branch & bound | 1 | Exponential | Small graphs |
+
+</details>
+
+## Reference: anti-patterns to avoid
+
+<details>
+<summary>Common mistakes specific to this week's topic</summary>
+
+
+- **Calling something "NP-hard" without a polynomial-time reduction** — hardness needs a reduction from a known NP-hard problem. "It looks hard" is not a proof; you may have missed a polynomial algorithm.
+- **Confusing NP-complete with "impossible"** — NP-hard problems can have great approximations, heuristics, FPT algorithms, or fast solvers on real-world (non-adversarial) inputs. SAT solvers handle millions of variables every day.
+- **Implementing a 2-approximation and reporting "within 2× optimal" without proving the bound on your variant** — modifying the standard algorithm often breaks the proof. Cite the exact theorem or re-prove it.
+- **Reducing in the wrong direction** — to show your problem X is hard, reduce a known-hard problem *to* X, not the other way around. Reducing X to SAT only shows X is in NP, which is much weaker.
+- **Treating PTAS / FPTAS / APX as interchangeable** — a PTAS gives `(1+ε)`-approximation in time that may be doubly exponential in `1/ε`; an FPTAS keeps it polynomial in `1/ε`; APX is the class of constant-factor approximable. These are different guarantees.
+
+</details>
+
+## Reference: how to run a topic file
+
+<details>
+<summary>Java / Python / C++ / Rust / Web one-liners</summary>
+
 
 From the week's directory:
 
@@ -42,40 +124,10 @@ open web/<file>.html   # macOS
 xdg-open web/<file>.html   # Linux
 ```
 
-## Topic roadmap
-
-- **1. ResearchLevelTopics**
-- **2. NPCompletenessAndApproximation**
-
-## Tradeoff Matrix
-
-Flagship topic: NP-completeness and approximation algorithms.
-
-| Approach (NP-hard problem strategies) | Quality | Time | When to prefer |
-|----------|------|------|----------------|
-| Exact exponential (DP, B&B) | Optimal | Exponential | Small inputs (n ≤ 30-50 with good pruning) |
-| Approximation algorithm | Bounded factor (e.g. 2× optimal) | Polynomial | Need a worst-case guarantee |
-| Heuristic / local search | No guarantee, often great | Polynomial | Real-world solvers (SAT, TSP) |
-| Randomized (Las Vegas / Monte Carlo) | Probabilistic guarantee | Polynomial expected | When randomness breaks adversarial inputs |
-| Parameterized / FPT algorithms | Optimal | f(k) · poly(n) | Small "parameter" k even if n is large |
-| ILP solver | Optimal | Black-box exponential | When modeling beats hand-coding |
-
-| Approach (Vertex Cover) | Approximation ratio | Time | When to prefer |
-|----------|------|------|----------------|
-| Greedy by highest degree | log n | O(E log V) | Quick baseline |
-| Pick both endpoints of any uncovered edge | 2 | O(E) | Provable 2-approximation |
-| LP relaxation + rounding | 2 | poly | When you already have an LP solver |
-| Exact branch & bound | 1 | Exponential | Small graphs |
-
-## Anti-patterns to avoid
-
-- **Calling something "NP-hard" without a polynomial-time reduction** — hardness needs a reduction from a known NP-hard problem. "It looks hard" is not a proof; you may have missed a polynomial algorithm.
-- **Confusing NP-complete with "impossible"** — NP-hard problems can have great approximations, heuristics, FPT algorithms, or fast solvers on real-world (non-adversarial) inputs. SAT solvers handle millions of variables every day.
-- **Implementing a 2-approximation and reporting "within 2× optimal" without proving the bound on your variant** — modifying the standard algorithm often breaks the proof. Cite the exact theorem or re-prove it.
-- **Reducing in the wrong direction** — to show your problem X is hard, reduce a known-hard problem *to* X, not the other way around. Reducing X to SAT only shows X is in NP, which is much weaker.
-- **Treating PTAS / FPTAS / APX as interchangeable** — a PTAS gives `(1+ε)`-approximation in time that may be doubly exponential in `1/ε`; an FPTAS keeps it polynomial in `1/ε`; APX is the class of constant-factor approximable. These are different guarantees.
+</details>
 
 ## Reflection prompts
+
 
 - Which topic this week was hardest, and what made it hard?
 - Was there a pattern you didn't recognize and had to be told about? Which one?

--- a/Week 25/README.md
+++ b/Week 25/README.md
@@ -1,10 +1,40 @@
-# Week 25
+# Week 25 — Advanced String Algorithms
 
-> Self-check: `./scripts/journey quiz 25` — run the mastery checkpoints for this week.
+> Self-check: `./scripts/journey quiz 25`  |  Next session: `./scripts/journey next`
 
-Each topic is implemented in all five languages: **Java, Python, C++, Rust, and Web (HTML/JS)**. The Java track is the primary detailed walkthrough; the others mirror it with idiomatic constructs.
+## Today's session (~45 min)
 
-## Topic index
+1. **Concept** (10 min) — Read [`python/1.kmp.py`](python/1.kmp.py) (CONCEPT + KEY POINTS blocks).
+2. **Recognize the pattern** (5 min) — Try drills 1-5 in [`patterns.md`](patterns.md) cold.
+3. **Implement from spec** (20 min) — Pick Challenge 1 from [`challenges.md`](challenges.md). Code it in `workbook/week_25/attempts/`.
+4. **Verify YOUR code** (5 min) — `./scripts/journey verify kmp_search workbook/week_25/attempts/<your-file>.py`
+5. **Mastery quiz** (5 min) — `./scripts/journey quiz 25`
+
+If you got stuck: open [`python/1.kmp.py`](python/1.kmp.py) and diff against your attempt.
+If you finish early: drills 6-10 in `patterns.md`, or Challenge 2.
+
+**Primary language: Python.** Want to compare implementations? See the per-language table below.
+
+---
+
+## Topic overview
+
+This week covers **Advanced String Algorithms**. You'll touch: KMP, RabinKarp, ZAlgorithm. The flagship algorithm/concept for the week is implemented in all five languages, and the Python file listed in Today's session is the canonical walkthrough.
+
+## Related materials
+
+| Resource | Use it when |
+|----------|-------------|
+| Capstone: [`capstones/phase_5_leaderboard_service.md`](../capstones/phase_5_leaderboard_service.md) | Phase 5 capstone — apply what you learned in weeks 21-25 |
+| [`problems.md`](problems.md) | You want extra practice with company-tagged problems |
+
+## Reference: per-language topic index
+
+<details>
+<summary>All implementations (Java / Python / C++ / Rust / Web)</summary>
+
+**Topic index**
+
 
 | # | Topic | Java | Python | C++ | Rust | Web |
 |---|-------|------|--------|-----|------|-----|
@@ -12,7 +42,8 @@ Each topic is implemented in all five languages: **Java, Python, C++, Rust, and 
 | 2 | RabinKarp | `java/2.RabinKarp.java` | `python/2.rabin_karp.py` | `cpp/2.rabin_karp.cpp` | `rust/s02_rabin_karp.rs` | `web/2.rabin_karp.html` |
 | 3 | ZAlgorithm | `java/3.ZAlgorithm.java` | `python/3.z_algorithm.py` | `cpp/3.z_algorithm.cpp` | `rust/s03_z_algorithm.rs` | `web/3.z_algorithm.html` |
 
-## Survey companions
+**Survey companions**
+
 
 Cross-cutting files that summarize the week or provide an interactive overview:
 
@@ -21,7 +52,54 @@ Cross-cutting files that summarize the week or provide an interactive overview:
 | String Algorithms | `java/string_algorithms.java` | `python/string_algorithms.py` | `cpp/string_algorithms.cpp` | `rust/string_algorithms.rs` | `web/string_algorithms.html` |
 | Interactive index | — | — | — | — | `web/index.html` |
 
-## How to run a topic file
+**Topic roadmap**
+
+
+- **1. KMP**
+- **2. RabinKarp**
+- **3. ZAlgorithm**
+
+</details>
+
+## Reference: tradeoff matrix
+
+<details>
+<summary>Approach x Time x Space x When-to-prefer</summary>
+
+
+Flagship topic: String matching algorithms (KMP, Rabin–Karp, Z).
+
+| Approach | Preprocessing | Search | Space | When to prefer |
+|----------|------|--------|-------|----------------|
+| Naive | 0 | O(N·M) | O(1) | Small inputs, or as a baseline |
+| KMP (failure function) | O(M) | O(N) | O(M) | Single pattern, worst-case guarantee |
+| Rabin–Karp (rolling hash) | O(M) | O(N) avg, O(N·M) worst | O(1) | Multiple patterns of same length, plagiarism detection |
+| Z-algorithm | O(N+M) | included | O(N+M) | Need all matches plus prefix info |
+| Boyer–Moore (bad char + good suffix) | O(M + Σ) | O(N/M) best, O(N·M) worst | O(M + Σ) | Long patterns, large alphabet (`grep`'s default) |
+| Aho–Corasick | O(Σ Mi) | O(N + matches) | O(Σ Mi · Σ) | Many patterns at once |
+| Suffix Automaton / Suffix Array | O(N) / O(N log N) | varies | O(N) | Repeated queries on one fixed text |
+
+</details>
+
+## Reference: anti-patterns to avoid
+
+<details>
+<summary>Common mistakes specific to this week's topic</summary>
+
+
+- **Computing KMP's failure function with a single nested loop and `if (s[i]==s[j]) j++; else j=0`** — resetting `j` to 0 on mismatch is the bug version. The correct fallback is `j = failure[j-1]` (recursively), which is the entire point of KMP.
+- **Rabin–Karp with a single hash and no verification** — collisions happen; once you find a match by hash you must verify character-by-character. Without verification you'll occasionally report false positives.
+- **Using `String.substring` inside the matching loop** — in modern Java that's an O(M) allocation per index, turning your O(N) algorithm into O(N·M). Compare characters with `charAt` directly.
+- **Z-algorithm with the `[l, r]` window updated incorrectly** — when `i + Z[i-l] >= r`, you must extend by character comparison and update `(l, r)`. Skipping that update breaks every subsequent index.
+- **Treating Boyer–Moore as "obviously faster"** — its worst case on patterns like `aaaa...a` in text `aaaa...ab` is O(N·M). For adversarial inputs use KMP, which is worst-case O(N+M).
+
+</details>
+
+## Reference: how to run a topic file
+
+<details>
+<summary>Java / Python / C++ / Rust / Web one-liners</summary>
+
 
 From the week's directory:
 
@@ -43,35 +121,10 @@ open web/<file>.html   # macOS
 xdg-open web/<file>.html   # Linux
 ```
 
-## Topic roadmap
-
-- **1. KMP**
-- **2. RabinKarp**
-- **3. ZAlgorithm**
-
-## Tradeoff Matrix
-
-Flagship topic: String matching algorithms (KMP, Rabin–Karp, Z).
-
-| Approach | Preprocessing | Search | Space | When to prefer |
-|----------|------|--------|-------|----------------|
-| Naive | 0 | O(N·M) | O(1) | Small inputs, or as a baseline |
-| KMP (failure function) | O(M) | O(N) | O(M) | Single pattern, worst-case guarantee |
-| Rabin–Karp (rolling hash) | O(M) | O(N) avg, O(N·M) worst | O(1) | Multiple patterns of same length, plagiarism detection |
-| Z-algorithm | O(N+M) | included | O(N+M) | Need all matches plus prefix info |
-| Boyer–Moore (bad char + good suffix) | O(M + Σ) | O(N/M) best, O(N·M) worst | O(M + Σ) | Long patterns, large alphabet (`grep`'s default) |
-| Aho–Corasick | O(Σ Mi) | O(N + matches) | O(Σ Mi · Σ) | Many patterns at once |
-| Suffix Automaton / Suffix Array | O(N) / O(N log N) | varies | O(N) | Repeated queries on one fixed text |
-
-## Anti-patterns to avoid
-
-- **Computing KMP's failure function with a single nested loop and `if (s[i]==s[j]) j++; else j=0`** — resetting `j` to 0 on mismatch is the bug version. The correct fallback is `j = failure[j-1]` (recursively), which is the entire point of KMP.
-- **Rabin–Karp with a single hash and no verification** — collisions happen; once you find a match by hash you must verify character-by-character. Without verification you'll occasionally report false positives.
-- **Using `String.substring` inside the matching loop** — in modern Java that's an O(M) allocation per index, turning your O(N) algorithm into O(N·M). Compare characters with `charAt` directly.
-- **Z-algorithm with the `[l, r]` window updated incorrectly** — when `i + Z[i-l] >= r`, you must extend by character comparison and update `(l, r)`. Skipping that update breaks every subsequent index.
-- **Treating Boyer–Moore as "obviously faster"** — its worst case on patterns like `aaaa...a` in text `aaaa...ab` is O(N·M). For adversarial inputs use KMP, which is worst-case O(N+M).
+</details>
 
 ## Reflection prompts
+
 
 - Which topic this week was hardest, and what made it hard?
 - Was there a pattern you didn't recognize and had to be told about? Which one?

--- a/Week 26/README.md
+++ b/Week 26/README.md
@@ -1,10 +1,39 @@
-# Week 26
+# Week 26 — Network Flow & Matching
 
-> Self-check: `./scripts/journey quiz 26` — run the mastery checkpoints for this week.
+> Self-check: `./scripts/journey quiz 26`  |  Next session: `./scripts/journey next`
 
-Each topic is implemented in all five languages: **Java, Python, C++, Rust, and Web (HTML/JS)**. The Java track is the primary detailed walkthrough; the others mirror it with idiomatic constructs.
+## Today's session (~45 min)
 
-## Topic index
+1. **Concept** (10 min) — Read [`python/edmonds_karp.py`](python/edmonds_karp.py) (CONCEPT + KEY POINTS blocks).
+2. **Recognize the pattern** (5 min) — Try drills 1-5 in [`patterns.md`](patterns.md) cold.
+3. **Implement from spec** (20 min) — Pick Challenge 1 from [`challenges.md`](challenges.md). Code it in `workbook/week_26/attempts/`.
+4. **Verify YOUR code** (5 min) — `./scripts/journey verify max_flow_min_cut workbook/week_26/attempts/<your-file>.py`
+5. **Mastery quiz** (5 min) — `./scripts/journey quiz 26`
+
+If you got stuck: open [`python/edmonds_karp.py`](python/edmonds_karp.py) and diff against your attempt.
+If you finish early: drills 6-10 in `patterns.md`, or Challenge 2.
+
+**Primary language: Python.** Want to compare implementations? See the per-language table below.
+
+---
+
+## Topic overview
+
+This week covers **Network Flow & Matching**. You'll touch: bipartite matching, dinic, edmonds karp, ford fulkerson, min cut, network flow. The flagship algorithm/concept for the week is implemented in all five languages, and the Python file listed in Today's session is the canonical walkthrough.
+
+## Related materials
+
+| Resource | Use it when |
+|----------|-------------|
+| [`problems.md`](problems.md) | You want extra practice with company-tagged problems |
+
+## Reference: per-language topic index
+
+<details>
+<summary>All implementations (Java / Python / C++ / Rust / Web)</summary>
+
+**Topic index**
+
 
 | # | Topic | Java | Python | C++ | Rust | Web |
 |---|-------|------|--------|-----|------|-----|
@@ -15,7 +44,8 @@ Each topic is implemented in all five languages: **Java, Python, C++, Rust, and 
 | 5 | min cut | `java/min_cut.java` | `python/min_cut.py` | `cpp/min_cut.cpp` | `rust/min_cut.rs` | `web/min_cut.html` |
 | 6 | network flow | `java/network_flow.java` | `python/network_flow.py` | `cpp/network_flow.cpp` | `rust/network_flow.rs` | — |
 
-## Survey companions
+**Survey companions**
+
 
 Cross-cutting files that summarize the week or provide an interactive overview:
 
@@ -23,7 +53,62 @@ Cross-cutting files that summarize the week or provide an interactive overview:
 |-------|------|--------|-----|------|-----|
 | Interactive index | — | — | — | — | `web/index.html` |
 
-## How to run a topic file
+**Topic roadmap**
+
+
+- **1. bipartite matching**
+- **2. dinic**
+- **3. edmonds karp**
+- **4. ford fulkerson**
+- **5. min cut**
+- **6. network flow**
+
+</details>
+
+## Reference: tradeoff matrix
+
+<details>
+<summary>Approach x Time x Space x When-to-prefer</summary>
+
+
+Flagship topic: Network flow (Ford–Fulkerson, Edmonds–Karp, Dinic, bipartite matching, min cut).
+
+| Approach | Time | Space | When to prefer |
+|----------|------|-------|----------------|
+| Ford–Fulkerson (DFS augmenting paths) | O(E · max_flow) | O(V + E) | Integer capacities, small max_flow; can loop forever on irrationals |
+| Edmonds–Karp (BFS augmenting paths) | O(V · E²) | O(V + E) | General case, simple to implement |
+| Dinic's algorithm | O(V² · E) general, O(E √V) unit capacities | O(V + E) | Default for large graphs and bipartite matching |
+| Push–Relabel | O(V² √E) | O(V + E) | Dense graphs; great practical constants |
+| ISAP (improved push–relabel) | O(V² √E) | O(V + E) | Highest practical throughput |
+| Hopcroft–Karp (bipartite matching) | O(E √V) | O(V + E) | Pure bipartite matching |
+
+| Approach (min cut) | Time | Space | When to prefer |
+|----------|------|-------|----------------|
+| Max-flow then reachability from source | O(max-flow algorithm) | O(V + E) | s-t min cut |
+| Stoer–Wagner | O(V·E + V² log V) | O(V²) | Global min cut on undirected graphs |
+| Karger's randomized | O(V²) per run, O(V² log V) high-prob | O(V + E) | Approximation; simple Monte Carlo |
+
+</details>
+
+## Reference: anti-patterns to avoid
+
+<details>
+<summary>Common mistakes specific to this week's topic</summary>
+
+
+- **Ford–Fulkerson on capacities given as floats** — augmenting-path search can choose paths whose sum never reaches max flow (classic Zwick example). Stick to integers, or use Edmonds–Karp/Dinic which terminate regardless.
+- **Forgetting to add reverse edges with capacity 0** — without them, augmenting paths can't "undo" earlier choices and you'll under-report max flow. Every edge `u→v` needs a back-edge `v→u` initialized to 0.
+- **Modeling vertex capacities by clamping flow at a vertex** — the standard trick is to split each vertex into `v_in → v_out` with the vertex capacity on that edge. Trying to enforce it post-hoc never works.
+- **Bipartite matching by greedy augmenting without alternating paths** — greedy matching is a 1/2-approximation, not optimal. Use augmenting-path search (Hungarian/Hopcroft–Karp) for maximum matching.
+- **Reading Dinic's BFS level graph but not maintaining a `currentEdge[]` pointer** — without it, each DFS revisits saturated edges and the complexity bound breaks. The `currentEdge[]` ("dead end" pointer) is what makes Dinic Dinic.
+
+</details>
+
+## Reference: how to run a topic file
+
+<details>
+<summary>Java / Python / C++ / Rust / Web one-liners</summary>
+
 
 From the week's directory:
 
@@ -45,43 +130,10 @@ open web/<file>.html   # macOS
 xdg-open web/<file>.html   # Linux
 ```
 
-## Topic roadmap
-
-- **1. bipartite matching**
-- **2. dinic**
-- **3. edmonds karp**
-- **4. ford fulkerson**
-- **5. min cut**
-- **6. network flow**
-
-## Tradeoff Matrix
-
-Flagship topic: Network flow (Ford–Fulkerson, Edmonds–Karp, Dinic, bipartite matching, min cut).
-
-| Approach | Time | Space | When to prefer |
-|----------|------|-------|----------------|
-| Ford–Fulkerson (DFS augmenting paths) | O(E · max_flow) | O(V + E) | Integer capacities, small max_flow; can loop forever on irrationals |
-| Edmonds–Karp (BFS augmenting paths) | O(V · E²) | O(V + E) | General case, simple to implement |
-| Dinic's algorithm | O(V² · E) general, O(E √V) unit capacities | O(V + E) | Default for large graphs and bipartite matching |
-| Push–Relabel | O(V² √E) | O(V + E) | Dense graphs; great practical constants |
-| ISAP (improved push–relabel) | O(V² √E) | O(V + E) | Highest practical throughput |
-| Hopcroft–Karp (bipartite matching) | O(E √V) | O(V + E) | Pure bipartite matching |
-
-| Approach (min cut) | Time | Space | When to prefer |
-|----------|------|-------|----------------|
-| Max-flow then reachability from source | O(max-flow algorithm) | O(V + E) | s-t min cut |
-| Stoer–Wagner | O(V·E + V² log V) | O(V²) | Global min cut on undirected graphs |
-| Karger's randomized | O(V²) per run, O(V² log V) high-prob | O(V + E) | Approximation; simple Monte Carlo |
-
-## Anti-patterns to avoid
-
-- **Ford–Fulkerson on capacities given as floats** — augmenting-path search can choose paths whose sum never reaches max flow (classic Zwick example). Stick to integers, or use Edmonds–Karp/Dinic which terminate regardless.
-- **Forgetting to add reverse edges with capacity 0** — without them, augmenting paths can't "undo" earlier choices and you'll under-report max flow. Every edge `u→v` needs a back-edge `v→u` initialized to 0.
-- **Modeling vertex capacities by clamping flow at a vertex** — the standard trick is to split each vertex into `v_in → v_out` with the vertex capacity on that edge. Trying to enforce it post-hoc never works.
-- **Bipartite matching by greedy augmenting without alternating paths** — greedy matching is a 1/2-approximation, not optimal. Use augmenting-path search (Hungarian/Hopcroft–Karp) for maximum matching.
-- **Reading Dinic's BFS level graph but not maintaining a `currentEdge[]` pointer** — without it, each DFS revisits saturated edges and the complexity bound breaks. The `currentEdge[]` ("dead end" pointer) is what makes Dinic Dinic.
+</details>
 
 ## Reflection prompts
+
 
 - Which topic this week was hardest, and what made it hard?
 - Was there a pattern you didn't recognize and had to be told about? Which one?

--- a/Week 27/README.md
+++ b/Week 27/README.md
@@ -1,10 +1,39 @@
-# Week 27
+# Week 27 — Computational Geometry
 
-> Self-check: `./scripts/journey quiz 27` — run the mastery checkpoints for this week.
+> Self-check: `./scripts/journey quiz 27`  |  Next session: `./scripts/journey next`
 
-Each topic is implemented in all five languages: **Java, Python, C++, Rust, and Web (HTML/JS)**. The Java track is the primary detailed walkthrough; the others mirror it with idiomatic constructs.
+## Today's session (~45 min)
 
-## Topic index
+1. **Concept** (10 min) — Read [`python/convex_hull.py`](python/convex_hull.py) (CONCEPT + KEY POINTS blocks).
+2. **Recognize the pattern** (5 min) — Try drills 1-5 in [`patterns.md`](patterns.md) cold.
+3. **Implement from spec** (20 min) — Pick Challenge 1 from [`challenges.md`](challenges.md). Code it in `workbook/week_27/attempts/`.
+4. **Verify YOUR code** (5 min) — `./scripts/journey verify cross_product_sign workbook/week_27/attempts/<your-file>.py`
+5. **Mastery quiz** (5 min) — `./scripts/journey quiz 27`
+
+If you got stuck: open [`python/convex_hull.py`](python/convex_hull.py) and diff against your attempt.
+If you finish early: drills 6-10 in `patterns.md`, or Challenge 2.
+
+**Primary language: Python.** Want to compare implementations? See the per-language table below.
+
+---
+
+## Topic overview
+
+This week covers **Computational Geometry**. You'll touch: closest pair, convex hull, geometry, line intersection, sweep line. The flagship algorithm/concept for the week is implemented in all five languages, and the Python file listed in Today's session is the canonical walkthrough.
+
+## Related materials
+
+| Resource | Use it when |
+|----------|-------------|
+| [`problems.md`](problems.md) | You want extra practice with company-tagged problems |
+
+## Reference: per-language topic index
+
+<details>
+<summary>All implementations (Java / Python / C++ / Rust / Web)</summary>
+
+**Topic index**
+
 
 | # | Topic | Java | Python | C++ | Rust | Web |
 |---|-------|------|--------|-----|------|-----|
@@ -14,7 +43,8 @@ Each topic is implemented in all five languages: **Java, Python, C++, Rust, and 
 | 4 | line intersection | `java/line_intersection.java` | `python/line_intersection.py` | `cpp/line_intersection.cpp` | `rust/line_intersection.rs` | `web/line_intersection.html` |
 | 5 | sweep line | `java/sweep_line.java` | `python/sweep_line.py` | `cpp/sweep_line.cpp` | `rust/sweep_line.rs` | `web/sweep_line.html` |
 
-## Survey companions
+**Survey companions**
+
 
 Cross-cutting files that summarize the week or provide an interactive overview:
 
@@ -22,7 +52,62 @@ Cross-cutting files that summarize the week or provide an interactive overview:
 |-------|------|--------|-----|------|-----|
 | Interactive index | — | — | — | — | `web/index.html` |
 
-## How to run a topic file
+**Topic roadmap**
+
+
+- **1. closest pair**
+- **2. convex hull**
+- **3. geometry**
+- **4. line intersection**
+- **5. sweep line**
+
+</details>
+
+## Reference: tradeoff matrix
+
+<details>
+<summary>Approach x Time x Space x When-to-prefer</summary>
+
+
+Flagship topic: Computational geometry (convex hull, closest pair, line intersection, sweep line).
+
+| Approach (convex hull) | Time | Space | When to prefer |
+|----------|------|-------|----------------|
+| Brute force (test each edge) | O(N³) | O(1) | N ≤ 100, pedagogy |
+| Jarvis march / gift wrapping | O(N · H) | O(N) | Output-sensitive when H (hull points) is small |
+| Graham scan | O(N log N) | O(N) | Default |
+| Andrew's monotone chain | O(N log N) | O(N) | Simpler than Graham; avoids polar-angle sort |
+| Chan's algorithm | O(N log H) | O(N) | Theoretically optimal output-sensitive |
+| QuickHull | O(N log N) avg, O(N²) worst | O(N) | Easy to parallelize |
+
+| Approach (closest pair) | Time | Space | When to prefer |
+|----------|------|-------|----------------|
+| Brute force | O(N²) | O(1) | N ≤ 2000 |
+| Sort + divide & conquer | O(N log N) | O(N) | Default theoretical answer |
+| Sweep line + balanced BST | O(N log N) | O(N) | Same complexity, simpler implementation |
+| Randomized grid | O(N) expected | O(N) | Practical for huge N |
+
+</details>
+
+## Reference: anti-patterns to avoid
+
+<details>
+<summary>Common mistakes specific to this week's topic</summary>
+
+
+- **Comparing floating-point coordinates with `==`** — almost guarantees nondeterministic behavior. Use an epsilon tolerance, or — better — work with integer coordinates and the cross product so all comparisons are exact.
+- **Cross product computed as `a.x * b.x + a.y * b.y`** — that's the dot product. The 2-D cross is `a.x * b.y - a.y * b.x`. Mixing them up corrupts orientation tests and every algorithm downstream.
+- **Convex hull with duplicate or collinear points handled inconsistently** — decide whether collinear points belong on the hull, then enforce it with `cross ≤ 0` vs `cross < 0` in your turn test. Different conventions produce different (both valid) hulls.
+- **Sweep-line events stored in a `HashSet`** — you need *ordered* events, sorted by x (and a tiebreak rule). Use a TreeSet/PQ; HashSet drops the order you depend on.
+- **Point-in-polygon by signed-area sum** — works only for convex polygons. For general polygons use ray casting (count crossings) or winding number.
+
+</details>
+
+## Reference: how to run a topic file
+
+<details>
+<summary>Java / Python / C++ / Rust / Web one-liners</summary>
+
 
 From the week's directory:
 
@@ -44,43 +129,10 @@ open web/<file>.html   # macOS
 xdg-open web/<file>.html   # Linux
 ```
 
-## Topic roadmap
-
-- **1. closest pair**
-- **2. convex hull**
-- **3. geometry**
-- **4. line intersection**
-- **5. sweep line**
-
-## Tradeoff Matrix
-
-Flagship topic: Computational geometry (convex hull, closest pair, line intersection, sweep line).
-
-| Approach (convex hull) | Time | Space | When to prefer |
-|----------|------|-------|----------------|
-| Brute force (test each edge) | O(N³) | O(1) | N ≤ 100, pedagogy |
-| Jarvis march / gift wrapping | O(N · H) | O(N) | Output-sensitive when H (hull points) is small |
-| Graham scan | O(N log N) | O(N) | Default |
-| Andrew's monotone chain | O(N log N) | O(N) | Simpler than Graham; avoids polar-angle sort |
-| Chan's algorithm | O(N log H) | O(N) | Theoretically optimal output-sensitive |
-| QuickHull | O(N log N) avg, O(N²) worst | O(N) | Easy to parallelize |
-
-| Approach (closest pair) | Time | Space | When to prefer |
-|----------|------|-------|----------------|
-| Brute force | O(N²) | O(1) | N ≤ 2000 |
-| Sort + divide & conquer | O(N log N) | O(N) | Default theoretical answer |
-| Sweep line + balanced BST | O(N log N) | O(N) | Same complexity, simpler implementation |
-| Randomized grid | O(N) expected | O(N) | Practical for huge N |
-
-## Anti-patterns to avoid
-
-- **Comparing floating-point coordinates with `==`** — almost guarantees nondeterministic behavior. Use an epsilon tolerance, or — better — work with integer coordinates and the cross product so all comparisons are exact.
-- **Cross product computed as `a.x * b.x + a.y * b.y`** — that's the dot product. The 2-D cross is `a.x * b.y - a.y * b.x`. Mixing them up corrupts orientation tests and every algorithm downstream.
-- **Convex hull with duplicate or collinear points handled inconsistently** — decide whether collinear points belong on the hull, then enforce it with `cross ≤ 0` vs `cross < 0` in your turn test. Different conventions produce different (both valid) hulls.
-- **Sweep-line events stored in a `HashSet`** — you need *ordered* events, sorted by x (and a tiebreak rule). Use a TreeSet/PQ; HashSet drops the order you depend on.
-- **Point-in-polygon by signed-area sum** — works only for convex polygons. For general polygons use ray casting (count crossings) or winding number.
+</details>
 
 ## Reflection prompts
+
 
 - Which topic this week was hardest, and what made it hard?
 - Was there a pattern you didn't recognize and had to be told about? Which one?

--- a/Week 28/README.md
+++ b/Week 28/README.md
@@ -1,10 +1,39 @@
-# Week 28
+# Week 28 — Game Theory & Combinatorics
 
-> Self-check: `./scripts/journey quiz 28` — run the mastery checkpoints for this week.
+> Self-check: `./scripts/journey quiz 28`  |  Next session: `./scripts/journey next`
 
-Each topic is implemented in all five languages: **Java, Python, C++, Rust, and Web (HTML/JS)**. The Java track is the primary detailed walkthrough; the others mirror it with idiomatic constructs.
+## Today's session (~45 min)
 
-## Topic index
+1. **Concept** (10 min) — Read [`python/nim.py`](python/nim.py) (CONCEPT + KEY POINTS blocks).
+2. **Recognize the pattern** (5 min) — Try drills 1-5 in [`patterns.md`](patterns.md) cold.
+3. **Implement from spec** (20 min) — Pick Challenge 1 from [`challenges.md`](challenges.md). Code it in `workbook/week_28/attempts/`.
+4. **Verify YOUR code** (5 min) — `./scripts/journey verify nim_xor_rule workbook/week_28/attempts/<your-file>.py`
+5. **Mastery quiz** (5 min) — `./scripts/journey quiz 28`
+
+If you got stuck: open [`python/nim.py`](python/nim.py) and diff against your attempt.
+If you finish early: drills 6-10 in `patterns.md`, or Challenge 2.
+
+**Primary language: Python.** Want to compare implementations? See the per-language table below.
+
+---
+
+## Topic overview
+
+This week covers **Game Theory & Combinatorics**. You'll touch: alpha beta, game theory, minimax, nim, sprague grundy. The flagship algorithm/concept for the week is implemented in all five languages, and the Python file listed in Today's session is the canonical walkthrough.
+
+## Related materials
+
+| Resource | Use it when |
+|----------|-------------|
+| [`problems.md`](problems.md) | You want extra practice with company-tagged problems |
+
+## Reference: per-language topic index
+
+<details>
+<summary>All implementations (Java / Python / C++ / Rust / Web)</summary>
+
+**Topic index**
+
 
 | # | Topic | Java | Python | C++ | Rust | Web |
 |---|-------|------|--------|-----|------|-----|
@@ -14,7 +43,8 @@ Each topic is implemented in all five languages: **Java, Python, C++, Rust, and 
 | 4 | nim | `java/nim.java` | `python/nim.py` | `cpp/nim.cpp` | `rust/nim.rs` | `web/nim.html` |
 | 5 | sprague grundy | `java/sprague_grundy.java` | `python/sprague_grundy.py` | `cpp/sprague_grundy.cpp` | `rust/sprague_grundy.rs` | `web/sprague_grundy.html` |
 
-## Survey companions
+**Survey companions**
+
 
 Cross-cutting files that summarize the week or provide an interactive overview:
 
@@ -22,7 +52,60 @@ Cross-cutting files that summarize the week or provide an interactive overview:
 |-------|------|--------|-----|------|-----|
 | Interactive index | — | — | — | — | `web/index.html` |
 
-## How to run a topic file
+**Topic roadmap**
+
+
+- **1. alpha beta**
+- **2. game theory**
+- **3. minimax**
+- **4. nim**
+- **5. sprague grundy**
+
+</details>
+
+## Reference: tradeoff matrix
+
+<details>
+<summary>Approach x Time x Space x When-to-prefer</summary>
+
+
+Flagship topic: Game theory and adversarial search (minimax, alpha-beta, Nim, Sprague–Grundy).
+
+| Approach (game search) | Time | Space | When to prefer |
+|----------|------|-------|----------------|
+| Minimax full tree | O(b^d) | O(d) | Tiny games, sanity oracle |
+| Minimax + alpha–beta pruning | O(b^(d/2)) best, O(b^d) worst | O(d) | Default for 2-player zero-sum games |
+| Alpha–beta + move ordering | close to O(b^(d/2)) consistently | O(d) | Production engines |
+| Iterative deepening + transposition table | O(b^(d/2)) with caching | O(states) | Time-controlled play, repeated positions |
+| Monte Carlo Tree Search (UCT) | Per-iteration cheap | O(visits) | Large branching factor, no good eval function |
+
+| Approach (impartial games) | Time | Space | When to prefer |
+|----------|------|-------|----------------|
+| Compute Grundy/Nim-value by full DP | O(states · transitions) | O(states) | Generic impartial games |
+| Sprague–Grundy XOR over independent piles | O(N) per query | O(1) | Sum of games (Nim, staircase Nim) |
+| Closed form / parity argument | O(1) | O(1) | Subtraction games with periodic Grundy sequence |
+
+</details>
+
+## Reference: anti-patterns to avoid
+
+<details>
+<summary>Common mistakes specific to this week's topic</summary>
+
+
+- **Alpha–beta with `alpha` and `beta` swapped on the recursive call** — must call as `(-beta, -alpha)` in negamax form, or pass the right windows in classic form. Swapping them silently turns pruning off (best case) or returns wrong values (worst case).
+- **Move ordering by insertion order** — the speedup from alpha–beta hinges on examining best moves first. Sort by a cheap heuristic (captures first, transposition-table hint) or you'll get worst-case `b^d`.
+- **Computing Grundy values by `XOR`-ing children directly** — the Grundy value of a position is `mex` (minimum excludant) of its children's Grundy values, not their XOR. XOR is for combining independent subgames in a sum.
+- **Forgetting the game must be *impartial* before applying Sprague–Grundy** — chess, checkers, and any game where the two players have different move sets are *partisan*. Sprague–Grundy doesn't apply; you need surreal numbers or game-specific analysis.
+- **Treating "the player to move wins iff Nim-sum ≠ 0"** as universal — that's the rule for *normal play* (last move wins). For *misère* play (last move loses), the rule is more subtle and only matches when all piles have size ≤ 1.
+
+</details>
+
+## Reference: how to run a topic file
+
+<details>
+<summary>Java / Python / C++ / Rust / Web one-liners</summary>
+
 
 From the week's directory:
 
@@ -44,41 +127,10 @@ open web/<file>.html   # macOS
 xdg-open web/<file>.html   # Linux
 ```
 
-## Topic roadmap
-
-- **1. alpha beta**
-- **2. game theory**
-- **3. minimax**
-- **4. nim**
-- **5. sprague grundy**
-
-## Tradeoff Matrix
-
-Flagship topic: Game theory and adversarial search (minimax, alpha-beta, Nim, Sprague–Grundy).
-
-| Approach (game search) | Time | Space | When to prefer |
-|----------|------|-------|----------------|
-| Minimax full tree | O(b^d) | O(d) | Tiny games, sanity oracle |
-| Minimax + alpha–beta pruning | O(b^(d/2)) best, O(b^d) worst | O(d) | Default for 2-player zero-sum games |
-| Alpha–beta + move ordering | close to O(b^(d/2)) consistently | O(d) | Production engines |
-| Iterative deepening + transposition table | O(b^(d/2)) with caching | O(states) | Time-controlled play, repeated positions |
-| Monte Carlo Tree Search (UCT) | Per-iteration cheap | O(visits) | Large branching factor, no good eval function |
-
-| Approach (impartial games) | Time | Space | When to prefer |
-|----------|------|-------|----------------|
-| Compute Grundy/Nim-value by full DP | O(states · transitions) | O(states) | Generic impartial games |
-| Sprague–Grundy XOR over independent piles | O(N) per query | O(1) | Sum of games (Nim, staircase Nim) |
-| Closed form / parity argument | O(1) | O(1) | Subtraction games with periodic Grundy sequence |
-
-## Anti-patterns to avoid
-
-- **Alpha–beta with `alpha` and `beta` swapped on the recursive call** — must call as `(-beta, -alpha)` in negamax form, or pass the right windows in classic form. Swapping them silently turns pruning off (best case) or returns wrong values (worst case).
-- **Move ordering by insertion order** — the speedup from alpha–beta hinges on examining best moves first. Sort by a cheap heuristic (captures first, transposition-table hint) or you'll get worst-case `b^d`.
-- **Computing Grundy values by `XOR`-ing children directly** — the Grundy value of a position is `mex` (minimum excludant) of its children's Grundy values, not their XOR. XOR is for combining independent subgames in a sum.
-- **Forgetting the game must be *impartial* before applying Sprague–Grundy** — chess, checkers, and any game where the two players have different move sets are *partisan*. Sprague–Grundy doesn't apply; you need surreal numbers or game-specific analysis.
-- **Treating "the player to move wins iff Nim-sum ≠ 0"** as universal — that's the rule for *normal play* (last move wins). For *misère* play (last move loses), the rule is more subtle and only matches when all piles have size ≤ 1.
+</details>
 
 ## Reflection prompts
+
 
 - Which topic this week was hardest, and what made it hard?
 - Was there a pattern you didn't recognize and had to be told about? Which one?

--- a/Week 29/README.md
+++ b/Week 29/README.md
@@ -1,10 +1,41 @@
-# Week 29
+# Week 29 — System Design for Engineers
 
-> Self-check: `./scripts/journey quiz 29` — run the mastery checkpoints for this week.
+> Self-check: `./scripts/journey quiz 29`  |  Next session: `./scripts/journey next`
 
-Each topic is implemented in all five languages: **Java, Python, C++, Rust, and Web (HTML/JS)**. The Java track is the primary detailed walkthrough; the others mirror it with idiomatic constructs.
+## Today's session (~45 min)
 
-## Topic index
+1. **Concept** (10 min) — Read [`python/caching.py`](python/caching.py) (CONCEPT + KEY POINTS blocks).
+2. **Recognize the pattern** (5 min) — Try drills 1-5 in [`patterns.md`](patterns.md) cold.
+3. **Implement from spec** (20 min) — Pick Challenge 1 from [`challenges.md`](challenges.md). Code it in `workbook/week_29/attempts/`.
+4. **Verify YOUR code** (5 min) — `./scripts/journey verify lru_data_structures workbook/week_29/attempts/<your-file>.py`
+5. **Mastery quiz** (5 min) — `./scripts/journey quiz 29`
+
+If you got stuck: open [`python/caching.py`](python/caching.py) and diff against your attempt.
+If you finish early: drills 6-10 in `patterns.md`, or Challenge 2.
+
+**Primary language: Python.** Want to compare implementations? See the per-language table below.
+
+---
+
+## Topic overview
+
+This week covers **System Design for Engineers**. You'll touch: caching, consistent hashing, message queues, rate limiting, sharding, system design. The flagship algorithm/concept for the week is implemented in all five languages, and the Python file listed in Today's session is the canonical walkthrough.
+
+## Related materials
+
+| Resource | Use it when |
+|----------|-------------|
+| Mock interview: [`mock_interviews/06_design_rate_limiter.md`](../mock_interviews/06_design_rate_limiter.md) | A system-design conversation about rate limiting |
+| Mock interview: [`mock_interviews/07_consistent_hashing_deep_dive.md`](../mock_interviews/07_consistent_hashing_deep_dive.md) | A deep-dive system-design conversation on consistent hashing |
+| [`problems.md`](problems.md) | You want extra practice with company-tagged problems |
+
+## Reference: per-language topic index
+
+<details>
+<summary>All implementations (Java / Python / C++ / Rust / Web)</summary>
+
+**Topic index**
+
 
 | # | Topic | Java | Python | C++ | Rust | Web |
 |---|-------|------|--------|-----|------|-----|
@@ -15,7 +46,8 @@ Each topic is implemented in all five languages: **Java, Python, C++, Rust, and 
 | 5 | sharding | `java/sharding.java` | `python/sharding.py` | `cpp/sharding.cpp` | `rust/sharding.rs` | `web/sharding.html` |
 | 6 | system design | `java/system_design.java` | `python/system_design.py` | `cpp/system_design.cpp` | `rust/system_design.rs` | — |
 
-## Survey companions
+**Survey companions**
+
 
 Cross-cutting files that summarize the week or provide an interactive overview:
 
@@ -23,29 +55,8 @@ Cross-cutting files that summarize the week or provide an interactive overview:
 |-------|------|--------|-----|------|-----|
 | Interactive index | — | — | — | — | `web/index.html` |
 
-## How to run a topic file
+**Topic roadmap**
 
-From the week's directory:
-
-```bash
-# Java
-javac java/<file>.java && java -cp java <ClassName>
-
-# Python
-python3 python/<file>.py
-
-# C++
-g++ -std=c++17 cpp/<file>.cpp -o /tmp/a && /tmp/a
-
-# Rust
-rustc --edition 2021 rust/<file>.rs -o /tmp/a && /tmp/a
-
-# Web — open in a browser
-open web/<file>.html   # macOS
-xdg-open web/<file>.html   # Linux
-```
-
-## Topic roadmap
 
 - **1. caching**
 - **2. consistent hashing**
@@ -54,7 +65,13 @@ xdg-open web/<file>.html   # Linux
 - **5. sharding**
 - **6. system design**
 
-## Tradeoff Matrix
+</details>
+
+## Reference: tradeoff matrix
+
+<details>
+<summary>Approach x Time x Space x When-to-prefer</summary>
+
 
 Flagship topic: System design building blocks (caching, consistent hashing, rate limiting, sharding, message queues).
 
@@ -81,7 +98,13 @@ Flagship topic: System design building blocks (caching, consistent hashing, rate
 | Consistent hashing + virtual nodes | O(data/N) | Low | Production default |
 | Range-based | Cheap key moves | Hot ranges possible | Range scans needed |
 
-## Anti-patterns to avoid
+</details>
+
+## Reference: anti-patterns to avoid
+
+<details>
+<summary>Common mistakes specific to this week's topic</summary>
+
 
 - **Caching without a TTL** — entries live forever, drift from the source of truth, and you'll be debugging "why is the user seeing 3-day-old data" for the rest of the quarter. Always set a TTL, even a generous one.
 - **Read-through cache with thundering herd on key expiry** — when a hot key expires, N concurrent requests all miss and stampede the DB. Use single-flight, request coalescing, or stagger expiries with jitter.
@@ -89,7 +112,38 @@ Flagship topic: System design building blocks (caching, consistent hashing, rate
 - **Building a message queue on top of a DB table and polling** — works for hundreds of messages/sec, falls over past that. Use a purpose-built queue (Kafka, SQS, RabbitMQ) before you scale.
 - **Treating rate limiting as a single-node problem when the service is horizontally scaled** — N replicas each enforcing `M` requests/sec allows `N·M` total. Use a shared store (Redis with Lua) or a sticky-routing layer.
 
+</details>
+
+## Reference: how to run a topic file
+
+<details>
+<summary>Java / Python / C++ / Rust / Web one-liners</summary>
+
+
+From the week's directory:
+
+```bash
+# Java
+javac java/<file>.java && java -cp java <ClassName>
+
+# Python
+python3 python/<file>.py
+
+# C++
+g++ -std=c++17 cpp/<file>.cpp -o /tmp/a && /tmp/a
+
+# Rust
+rustc --edition 2021 rust/<file>.rs -o /tmp/a && /tmp/a
+
+# Web — open in a browser
+open web/<file>.html   # macOS
+xdg-open web/<file>.html   # Linux
+```
+
+</details>
+
 ## Reflection prompts
+
 
 - Which topic this week was hardest, and what made it hard?
 - Was there a pattern you didn't recognize and had to be told about? Which one?

--- a/Week 3/README.md
+++ b/Week 3/README.md
@@ -1,10 +1,34 @@
-# Week 3
+# Week 3 — Loops & Number Theory Basics
 
-> Self-check: `./scripts/journey quiz 3` — run the mastery checkpoints for this week.
+> Self-check: `./scripts/journey quiz 3`  |  Next session: `./scripts/journey next`
 
-Each topic is implemented in all five languages: **Java, Python, C++, Rust, and Web (HTML/JS)**. The Java track is the primary detailed walkthrough; the others mirror it with idiomatic constructs.
+## Today's session (~30 min)
 
-## Topic index
+1. **Read & run** (15 min) — Walk through the python files in order: `1.*.py`, `2.*.py`, ... — actually run them.
+2. **Type along** (10 min) — Re-type 3 of them from scratch in `workbook/week_03/attempts/`. Don't copy-paste.
+3. **Self-check** (5 min) — `./scripts/journey quiz 3`
+
+Primary language: Python. Compare implementations in `java/`, `cpp/`, `rust/` to see how the same syntax looks across languages.
+
+---
+
+## Topic overview
+
+This week covers **Loops & Number Theory Basics**. You'll touch: For loop, For loop variations, Break, Continue, Scope of Variable, Increment Decrement Operator. The flagship algorithm/concept for the week is implemented in all five languages, and the Python file listed in Today's session is the canonical walkthrough.
+
+## Related materials
+
+| Resource | Use it when |
+|----------|-------------|
+| [`problems.md`](problems.md) | You want extra practice with company-tagged problems |
+
+## Reference: per-language topic index
+
+<details>
+<summary>All implementations (Java / Python / C++ / Rust / Web)</summary>
+
+**Topic index**
+
 
 | # | Topic | Java | Python | C++ | Rust | Web |
 |---|-------|------|--------|-----|------|-----|
@@ -25,7 +49,8 @@ Each topic is implemented in all five languages: **Java, Python, C++, Rust, and 
 | 15 | Decimal to Binary | `java/15.Decimal_to_Binary.java` | `python/15.decimal_to_binary.py` | `cpp/15.decimal_to_binary.cpp` | `rust/s15_decimal_to_binary.rs` | `web/15.decimal_to_binary.html` |
 | 16 | Check no Sequence | `java/16.Check_no_Sequence.java` | `python/16.check_no_sequence.py` | `cpp/16.check_no_sequence.cpp` | `rust/s16_check_no_sequence.rs` | `web/16.check_no_sequence.html` |
 
-## Survey companions
+**Survey companions**
+
 
 Cross-cutting files that summarize the week or provide an interactive overview:
 
@@ -34,7 +59,65 @@ Cross-cutting files that summarize the week or provide an interactive overview:
 | Loops And Numbers | — | `python/loops_and_numbers.py` | `cpp/loops_and_numbers.cpp` | `rust/loops_and_numbers.rs` | — |
 | Interactive index | — | — | — | — | `web/index.html` |
 
-## How to run a topic file
+**Topic roadmap**
+
+
+- **1. For loop**
+- **2. For loop variations**
+- **3. Break**
+- **4. Continue**
+- **5. Scope of Variable**
+- **6. Increment Decrement Operator**
+- **7. Bitwise Operator**
+- **8. Precedence Associativity**
+- **9. Nth Fibonacci Number**
+- **10. All Prime Number**
+- **11. Sum Or Product**
+- **12. Terms of AP**
+- **13. Reverse**
+- **14. Binary to Decimal**
+- **15. Decimal to Binary**
+- **16. Check no Sequence**
+
+</details>
+
+## Reference: tradeoff matrix
+
+<details>
+<summary>Approach x Time x Space x When-to-prefer</summary>
+
+
+Flagship topic: computing the Nth Fibonacci number.
+
+| Approach | Time | Space | Code complexity | When to prefer |
+|----------|------|-------|-----------------|----------------|
+| Naive recursion `fib(n-1)+fib(n-2)` | O(φⁿ) | O(n) stack | Low | Never for n > ~40 — pedagogy only |
+| Iterative (two variables) | O(n) | O(1) | Low | Default choice for all practical n |
+| Memoized recursion | O(n) | O(n) | Medium | When you also need intermediate values |
+| Matrix exponentiation | O(log n) | O(1) | High | Astronomical n with modular arithmetic |
+| Binet's formula | O(1) | O(1) | Low | When n is tiny and float error is OK |
+
+</details>
+
+## Reference: anti-patterns to avoid
+
+<details>
+<summary>Common mistakes specific to this week's topic</summary>
+
+
+- **Using `int` for Fibonacci past F(46)** — F(47) overflows a signed 32-bit int. Switch to `long` (good up to F(92)) or `BigInteger` for arbitrary n.
+- **Computing primality with `for i in 2..n`** — checking up to `sqrt(n)` is enough, since any factor larger than √n must pair with a smaller one. Wasting the upper half makes a 10× difference even on toy inputs.
+- **Building a decimal number from a binary string with `s += digit * Math.pow(2, i)`** — `Math.pow` returns `double` and you'll lose precision on long strings. Multiply-accumulate with `int`/`long` instead.
+- **Forgetting that `break` only exits the innermost loop** — if you're inside a nested loop and want to bail out of both, you need a labeled break or a flag, not a single `break`.
+- **Bitwise vs logical operators** — `&` and `&&` are different. `&` evaluates both sides; `&&` short-circuits. Mixing them up causes either subtle slowness or NullPointerExceptions on the right operand.
+
+</details>
+
+## Reference: how to run a topic file
+
+<details>
+<summary>Java / Python / C++ / Rust / Web one-liners</summary>
+
 
 From the week's directory:
 
@@ -56,46 +139,10 @@ open web/<file>.html   # macOS
 xdg-open web/<file>.html   # Linux
 ```
 
-## Topic roadmap
-
-- **1. For loop**
-- **2. For loop variations**
-- **3. Break**
-- **4. Continue**
-- **5. Scope of Variable**
-- **6. Increment Decrement Operator**
-- **7. Bitwise Operator**
-- **8. Precedence Associativity**
-- **9. Nth Fibonacci Number**
-- **10. All Prime Number**
-- **11. Sum Or Product**
-- **12. Terms of AP**
-- **13. Reverse**
-- **14. Binary to Decimal**
-- **15. Decimal to Binary**
-- **16. Check no Sequence**
-
-## Tradeoff Matrix
-
-Flagship topic: computing the Nth Fibonacci number.
-
-| Approach | Time | Space | Code complexity | When to prefer |
-|----------|------|-------|-----------------|----------------|
-| Naive recursion `fib(n-1)+fib(n-2)` | O(φⁿ) | O(n) stack | Low | Never for n > ~40 — pedagogy only |
-| Iterative (two variables) | O(n) | O(1) | Low | Default choice for all practical n |
-| Memoized recursion | O(n) | O(n) | Medium | When you also need intermediate values |
-| Matrix exponentiation | O(log n) | O(1) | High | Astronomical n with modular arithmetic |
-| Binet's formula | O(1) | O(1) | Low | When n is tiny and float error is OK |
-
-## Anti-patterns to avoid
-
-- **Using `int` for Fibonacci past F(46)** — F(47) overflows a signed 32-bit int. Switch to `long` (good up to F(92)) or `BigInteger` for arbitrary n.
-- **Computing primality with `for i in 2..n`** — checking up to `sqrt(n)` is enough, since any factor larger than √n must pair with a smaller one. Wasting the upper half makes a 10× difference even on toy inputs.
-- **Building a decimal number from a binary string with `s += digit * Math.pow(2, i)`** — `Math.pow` returns `double` and you'll lose precision on long strings. Multiply-accumulate with `int`/`long` instead.
-- **Forgetting that `break` only exits the innermost loop** — if you're inside a nested loop and want to bail out of both, you need a labeled break or a flag, not a single `break`.
-- **Bitwise vs logical operators** — `&` and `&&` are different. `&` evaluates both sides; `&&` short-circuits. Mixing them up causes either subtle slowness or NullPointerExceptions on the right operand.
+</details>
 
 ## Reflection prompts
+
 
 - Which topic this week was hardest, and what made it hard?
 - Was there a pattern you didn't recognize and had to be told about? Which one?

--- a/Week 30/README.md
+++ b/Week 30/README.md
@@ -1,10 +1,40 @@
-# Week 30
+# Week 30 — Interview Patterns & Mastery
 
-> Self-check: `./scripts/journey quiz 30` — run the mastery checkpoints for this week.
+> Self-check: `./scripts/journey quiz 30`  |  Next session: `./scripts/journey next`
 
-Each topic is implemented in all five languages: **Java, Python, C++, Rust, and Web (HTML/JS)**. The Java track is the primary detailed walkthrough; the others mirror it with idiomatic constructs.
+## Today's session (~45 min)
 
-## Topic index
+1. **Concept** (10 min) — Read [`python/two_pointers.py`](python/two_pointers.py) (CONCEPT + KEY POINTS blocks).
+2. **Recognize the pattern** (5 min) — Try drills 1-5 in [`patterns.md`](patterns.md) cold.
+3. **Implement from spec** (20 min) — Pick Challenge 1 from [`challenges.md`](challenges.md). Code it in `workbook/week_30/attempts/`.
+4. **Verify YOUR code** (5 min) — `./scripts/journey verify two_pointers_when workbook/week_30/attempts/<your-file>.py`
+5. **Mastery quiz** (5 min) — `./scripts/journey quiz 30`
+
+If you got stuck: open [`python/two_pointers.py`](python/two_pointers.py) and diff against your attempt.
+If you finish early: drills 6-10 in `patterns.md`, or Challenge 2.
+
+**Primary language: Python.** Want to compare implementations? See the per-language table below.
+
+---
+
+## Topic overview
+
+This week covers **Interview Patterns & Mastery**. You'll touch: fast slow pointers, interview patterns, merge intervals, sliding window, top k elements, two pointers. The flagship algorithm/concept for the week is implemented in all five languages, and the Python file listed in Today's session is the canonical walkthrough.
+
+## Related materials
+
+| Resource | Use it when |
+|----------|-------------|
+| Capstone: [`capstones/phase_6_tinyurl_with_consistent_hashing.md`](../capstones/phase_6_tinyurl_with_consistent_hashing.md) | Phase 6 capstone — apply what you learned in weeks 26-30 |
+| [`problems.md`](problems.md) | You want extra practice with company-tagged problems |
+
+## Reference: per-language topic index
+
+<details>
+<summary>All implementations (Java / Python / C++ / Rust / Web)</summary>
+
+**Topic index**
+
 
 | # | Topic | Java | Python | C++ | Rust | Web |
 |---|-------|------|--------|-----|------|-----|
@@ -15,7 +45,8 @@ Each topic is implemented in all five languages: **Java, Python, C++, Rust, and 
 | 5 | top k elements | `java/top_k_elements.java` | `python/top_k_elements.py` | `cpp/top_k_elements.cpp` | `rust/top_k_elements.rs` | `web/top_k_elements.html` |
 | 6 | two pointers | `java/two_pointers.java` | `python/two_pointers.py` | `cpp/two_pointers.cpp` | `rust/two_pointers.rs` | `web/two_pointers.html` |
 
-## Survey companions
+**Survey companions**
+
 
 Cross-cutting files that summarize the week or provide an interactive overview:
 
@@ -23,29 +54,8 @@ Cross-cutting files that summarize the week or provide an interactive overview:
 |-------|------|--------|-----|------|-----|
 | Interactive index | — | — | — | — | `web/index.html` |
 
-## How to run a topic file
+**Topic roadmap**
 
-From the week's directory:
-
-```bash
-# Java
-javac java/<file>.java && java -cp java <ClassName>
-
-# Python
-python3 python/<file>.py
-
-# C++
-g++ -std=c++17 cpp/<file>.cpp -o /tmp/a && /tmp/a
-
-# Rust
-rustc --edition 2021 rust/<file>.rs -o /tmp/a && /tmp/a
-
-# Web — open in a browser
-open web/<file>.html   # macOS
-xdg-open web/<file>.html   # Linux
-```
-
-## Topic roadmap
 
 - **1. fast slow pointers**
 - **2. interview patterns**
@@ -54,7 +64,13 @@ xdg-open web/<file>.html   # Linux
 - **5. top k elements**
 - **6. two pointers**
 
-## Tradeoff Matrix
+</details>
+
+## Reference: tradeoff matrix
+
+<details>
+<summary>Approach x Time x Space x When-to-prefer</summary>
+
 
 Flagship topic: Interview patterns (sliding window, two pointers, fast/slow, merge intervals, top-K).
 
@@ -77,7 +93,13 @@ Flagship topic: Interview patterns (sliding window, two pointers, fast/slow, mer
 | Floyd's tortoise & hare | O(N) | O(1) | Default — constant space |
 | Brent's algorithm | O(N) | O(1) | ~36% fewer iterations than Floyd's in practice |
 
-## Anti-patterns to avoid
+</details>
+
+## Reference: anti-patterns to avoid
+
+<details>
+<summary>Common mistakes specific to this week's topic</summary>
+
 
 - **Sliding window where `right` and `left` advance in tangled loops** — the canonical shape is one outer `for right` and an inner `while (invariant broken) left++`. Reaching for two `while`s nested arbitrarily turns O(N) into O(N²) and breaks the invariant proof.
 - **Two-pointer on an unsorted array** — most two-pointer techniques (sorted-pair sum, container-with-most-water variant aside) assume sortedness. Sort first, or use a different pattern.
@@ -85,7 +107,38 @@ Flagship topic: Interview patterns (sliding window, two pointers, fast/slow, mer
 - **Merging intervals without sorting first** — the entire correctness argument depends on sorted-by-start order. Without it you'll merge non-overlapping intervals and miss overlapping ones.
 - **Top-K with a max-heap of size N** — works, but is O(N + k log N). A *min-heap of size k* is O(N log k), which is strictly better when k ≪ N. Inverting the heap by mistake is also why some people get "smallest k" when they wanted "largest k".
 
+</details>
+
+## Reference: how to run a topic file
+
+<details>
+<summary>Java / Python / C++ / Rust / Web one-liners</summary>
+
+
+From the week's directory:
+
+```bash
+# Java
+javac java/<file>.java && java -cp java <ClassName>
+
+# Python
+python3 python/<file>.py
+
+# C++
+g++ -std=c++17 cpp/<file>.cpp -o /tmp/a && /tmp/a
+
+# Rust
+rustc --edition 2021 rust/<file>.rs -o /tmp/a && /tmp/a
+
+# Web — open in a browser
+open web/<file>.html   # macOS
+xdg-open web/<file>.html   # Linux
+```
+
+</details>
+
 ## Reflection prompts
+
 
 - Which topic this week was hardest, and what made it hard?
 - Was there a pattern you didn't recognize and had to be told about? Which one?

--- a/Week 4/README.md
+++ b/Week 4/README.md
@@ -1,10 +1,39 @@
-# Week 4
+# Week 4 — Pattern Printing
 
-> Self-check: `./scripts/journey quiz 4` — run the mastery checkpoints for this week.
+> Self-check: `./scripts/journey quiz 4`  |  Next session: `./scripts/journey next`
 
-Each topic is implemented in all five languages: **Java, Python, C++, Rust, and Web (HTML/JS)**. The Java track is the primary detailed walkthrough; the others mirror it with idiomatic constructs.
+## Today's session (~45 min)
 
-## Topic index
+1. **Concept** (10 min) — Read [`python/1.square_pattern.py`](python/1.square_pattern.py) (CONCEPT + KEY POINTS blocks).
+2. **Recognize the pattern** (5 min) — Try drills 1-5 in [`patterns.md`](patterns.md) cold.
+3. **Implement from spec** (20 min) — Pick Challenge 1 from [`challenges.md`](challenges.md). Code it in `workbook/week_04/attempts/`.
+4. **Verify YOUR code** (5 min) — `./scripts/journey verify patterns workbook/week_04/attempts/<your-file>.py`
+5. **Mastery quiz** (5 min) — `./scripts/journey quiz 4`
+
+If you got stuck: open [`python/1.square_pattern.py`](python/1.square_pattern.py) and diff against your attempt.
+If you finish early: drills 6-10 in `patterns.md`, or Challenge 2.
+
+**Primary language: Python.** Want to compare implementations? See the per-language table below.
+
+---
+
+## Topic overview
+
+This week covers **Pattern Printing**. You'll touch: Square Pattern, Tri Star Pattern, Tri No pattern, Reverse Num Pattern, Alpha Pattern, Char Pattern. The flagship algorithm/concept for the week is implemented in all five languages, and the Python file listed in Today's session is the canonical walkthrough.
+
+## Related materials
+
+| Resource | Use it when |
+|----------|-------------|
+| [`problems.md`](problems.md) | You want extra practice with company-tagged problems |
+
+## Reference: per-language topic index
+
+<details>
+<summary>All implementations (Java / Python / C++ / Rust / Web)</summary>
+
+**Topic index**
+
 
 | # | Topic | Java | Python | C++ | Rust | Web |
 |---|-------|------|--------|-----|------|-----|
@@ -17,7 +46,8 @@ Each topic is implemented in all five languages: **Java, Python, C++, Rust, and 
 | 7 | Interesting Alphabet | `java/7.Interesting_Alphabet.java` | `python/7.interesting_alphabet.py` | `cpp/7.interesting_alphabet.cpp` | `rust/s07_interesting_alphabet.rs` | `web/7.interesting_alphabet.html` |
 | 8 | Mirror Image | `java/8.Mirror_Image.java` | `python/8.mirror_image.py` | `cpp/8.mirror_image.cpp` | `rust/s08_mirror_image.rs` | `web/8.mirror_image.html` |
 
-## Survey companions
+**Survey companions**
+
 
 Cross-cutting files that summarize the week or provide an interactive overview:
 
@@ -26,7 +56,56 @@ Cross-cutting files that summarize the week or provide an interactive overview:
 | Patterns | — | `python/patterns.py` | `cpp/patterns.cpp` | `rust/patterns.rs` | — |
 | Interactive index | — | — | — | — | `web/index.html` |
 
-## How to run a topic file
+**Topic roadmap**
+
+
+- **1. Square Pattern**
+- **2. Tri Star Pattern**
+- **3. Tri No pattern**
+- **4. Reverse Num Pattern**
+- **5. Alpha Pattern**
+- **6. Char Pattern**
+- **7. Interesting Alphabet**
+- **8. Mirror Image**
+
+</details>
+
+## Reference: tradeoff matrix
+
+<details>
+<summary>Approach x Time x Space x When-to-prefer</summary>
+
+
+Flagship topic: printing 2-D patterns (triangle / pyramid / mirror).
+
+| Approach | Time | Space | Code complexity | When to prefer |
+|----------|------|-------|-----------------|----------------|
+| Nested `for` loops, one print per cell | O(rows × cols) | O(1) | Low | Default for any pattern |
+| Build each row into a `StringBuilder`, print once | O(rows × cols) | O(cols) | Medium | When I/O latency dominates (many rows) |
+| Compute symmetry once, mirror | O(rows × cols/2) | O(1) | Medium | Palindromic / mirror patterns |
+| Recursive row printer | O(rows × cols) | O(rows) stack | Medium | When recursion is the lesson, not the goal |
+
+</details>
+
+## Reference: anti-patterns to avoid
+
+<details>
+<summary>Common mistakes specific to this week's topic</summary>
+
+
+- **Reaching for `String += ch` in a hot loop** — `String` is immutable in Java; every `+=` allocates a new object, turning an O(n) pattern into O(n²). Use `StringBuilder`.
+- **Computing the row count and the spaces independently** — they're linked. Express spaces as `total - row` (or similar) in one place; don't maintain two counters that must agree.
+- **Hard-coding the pattern for n=5 and hoping it generalizes** — always parameterize by `n` from the start. Patterns that only work for one size are a sign you haven't found the invariant.
+- **Mixing `print` and `println` inconsistently** — forgetting a single newline shifts everything below it and makes the bug look like an off-by-one in the loop. Print exactly one `\n` at the end of each row.
+- **Confusing row index with row width** — in an inverted pyramid, the printed character count *decreases* with row index. Draw two rows on paper before coding to confirm direction.
+
+</details>
+
+## Reference: how to run a topic file
+
+<details>
+<summary>Java / Python / C++ / Rust / Web one-liners</summary>
+
 
 From the week's directory:
 
@@ -48,37 +127,10 @@ open web/<file>.html   # macOS
 xdg-open web/<file>.html   # Linux
 ```
 
-## Topic roadmap
-
-- **1. Square Pattern**
-- **2. Tri Star Pattern**
-- **3. Tri No pattern**
-- **4. Reverse Num Pattern**
-- **5. Alpha Pattern**
-- **6. Char Pattern**
-- **7. Interesting Alphabet**
-- **8. Mirror Image**
-
-## Tradeoff Matrix
-
-Flagship topic: printing 2-D patterns (triangle / pyramid / mirror).
-
-| Approach | Time | Space | Code complexity | When to prefer |
-|----------|------|-------|-----------------|----------------|
-| Nested `for` loops, one print per cell | O(rows × cols) | O(1) | Low | Default for any pattern |
-| Build each row into a `StringBuilder`, print once | O(rows × cols) | O(cols) | Medium | When I/O latency dominates (many rows) |
-| Compute symmetry once, mirror | O(rows × cols/2) | O(1) | Medium | Palindromic / mirror patterns |
-| Recursive row printer | O(rows × cols) | O(rows) stack | Medium | When recursion is the lesson, not the goal |
-
-## Anti-patterns to avoid
-
-- **Reaching for `String += ch` in a hot loop** — `String` is immutable in Java; every `+=` allocates a new object, turning an O(n) pattern into O(n²). Use `StringBuilder`.
-- **Computing the row count and the spaces independently** — they're linked. Express spaces as `total - row` (or similar) in one place; don't maintain two counters that must agree.
-- **Hard-coding the pattern for n=5 and hoping it generalizes** — always parameterize by `n` from the start. Patterns that only work for one size are a sign you haven't found the invariant.
-- **Mixing `print` and `println` inconsistently** — forgetting a single newline shifts everything below it and makes the bug look like an off-by-one in the loop. Print exactly one `\n` at the end of each row.
-- **Confusing row index with row width** — in an inverted pyramid, the printed character count *decreases* with row index. Draw two rows on paper before coding to confirm direction.
+</details>
 
 ## Reflection prompts
+
 
 - Which topic this week was hardest, and what made it hard?
 - Was there a pattern you didn't recognize and had to be told about? Which one?

--- a/Week 5/README.md
+++ b/Week 5/README.md
@@ -1,10 +1,41 @@
-# Week 5
+# Week 5 — Functions & Recursion
 
-> Self-check: `./scripts/journey quiz 5` — run the mastery checkpoints for this week.
+> Self-check: `./scripts/journey quiz 5`  |  Next session: `./scripts/journey next`
 
-Each topic is implemented in all five languages: **Java, Python, C++, Rust, and Web (HTML/JS)**. The Java track is the primary detailed walkthrough; the others mirror it with idiomatic constructs.
+## Today's session (~45 min)
 
-## Topic index
+1. **Concept** (10 min) — Read [`python/3.recursion_basics.py`](python/3.recursion_basics.py) (CONCEPT + KEY POINTS blocks).
+2. **Recognize the pattern** (5 min) — Try drills 1-5 in [`patterns.md`](patterns.md) cold.
+3. **Implement from spec** (20 min) — Pick Challenge 1 from [`challenges.md`](challenges.md). Code it in `workbook/week_05/attempts/`.
+4. **Verify YOUR code** (5 min) — `./scripts/journey verify recursion workbook/week_05/attempts/<your-file>.py`
+5. **Mastery quiz** (5 min) — `./scripts/journey quiz 5`
+
+If you got stuck: open [`python/3.recursion_basics.py`](python/3.recursion_basics.py) and diff against your attempt.
+If you finish early: drills 6-10 in `patterns.md`, or Challenge 2.
+
+**Primary language: Python.** Want to compare implementations? See the per-language table below.
+
+---
+
+## Topic overview
+
+This week covers **Functions & Recursion**. You'll touch: MethodBasics, MethodOverloading, RecursionBasics, FibonacciRecursion, TowerOfHanoi, RecursionPatterns. The flagship algorithm/concept for the week is implemented in all five languages, and the Python file listed in Today's session is the canonical walkthrough.
+
+## Related materials
+
+| Resource | Use it when |
+|----------|-------------|
+| Visualization: [`viz/recursion_tree.html`](../viz/recursion_tree.html) | You want to SEE recursion unfold as a call tree |
+| Capstone: [`capstones/phase_1_cli_calculator.md`](../capstones/phase_1_cli_calculator.md) | Phase 1 capstone — apply what you learned in weeks 1-5 |
+| [`problems.md`](problems.md) | You want extra practice with company-tagged problems |
+
+## Reference: per-language topic index
+
+<details>
+<summary>All implementations (Java / Python / C++ / Rust / Web)</summary>
+
+**Topic index**
+
 
 | # | Topic | Java | Python | C++ | Rust | Web |
 |---|-------|------|--------|-----|------|-----|
@@ -15,7 +46,8 @@ Each topic is implemented in all five languages: **Java, Python, C++, Rust, and 
 | 5 | TowerOfHanoi | `java/5.TowerOfHanoi.java` | `python/5.tower_of_hanoi.py` | `cpp/5.tower_of_hanoi.cpp` | `rust/s05_tower_of_hanoi.rs` | `web/5.tower_of_hanoi.html` |
 | 6 | RecursionPatterns | `java/6.RecursionPatterns.java` | `python/6.recursion_patterns.py` | `cpp/6.recursion_patterns.cpp` | `rust/s06_recursion_patterns.rs` | `web/6.recursion_patterns.html` |
 
-## Survey companions
+**Survey companions**
+
 
 Cross-cutting files that summarize the week or provide an interactive overview:
 
@@ -24,7 +56,59 @@ Cross-cutting files that summarize the week or provide an interactive overview:
 | Recursion | — | `python/recursion.py` | `cpp/recursion.cpp` | `rust/recursion.rs` | — |
 | Interactive index | — | — | — | — | `web/index.html` |
 
-## How to run a topic file
+**Topic roadmap**
+
+
+- **1. MethodBasics**
+- **2. MethodOverloading**
+- **3. RecursionBasics**
+- **4. FibonacciRecursion**
+- **5. TowerOfHanoi**
+- **6. RecursionPatterns**
+
+</details>
+
+## Reference: tradeoff matrix
+
+<details>
+<summary>Approach x Time x Space x When-to-prefer</summary>
+
+
+Flagship topic: solving the Tower of Hanoi (recursion).
+
+| Approach | Time | Space | Code complexity | When to prefer |
+|----------|------|-------|-----------------|----------------|
+| Classic recursion (move n-1, move 1, move n-1) | O(2ⁿ) | O(n) stack | Low | The canonical solution — clearest expression of the recurrence |
+| Iterative (binary counter / Frame–Stewart) | O(2ⁿ) | O(1) | High | When stack depth is a real concern |
+| Bitwise enumeration of moves | O(2ⁿ) | O(1) | High | Curiosity / understanding the move sequence |
+
+| Approach (Fibonacci recursion) | Time | Space | Code complexity | When to prefer |
+|----------|------|-------|-----------------|----------------|
+| Plain recursion | O(φⁿ) | O(n) | Low | Pedagogy only |
+| Memoized recursion | O(n) | O(n) | Medium | When you also need a recursion-shaped solution |
+| Tail-recursion-style iteration | O(n) | O(1) | Low | Production |
+
+</details>
+
+## Reference: anti-patterns to avoid
+
+<details>
+<summary>Common mistakes specific to this week's topic</summary>
+
+
+- **Calling a recursive method without a base case** — the first recursive call you write should immediately return on the smallest input. Without that, you get StackOverflowError instantly.
+- **Putting the base case after the recursive call** — order matters. The check must run *before* recursing, or you recurse one extra level into invalid input.
+- **Confusing "what the function returns" with "what it prints"** — pick one contract per method. Methods that both print and return are hard to test and hard to compose.
+- **Method overloading by argument *order* of the same types** — `foo(int a, int b)` and `foo(int b, int a)` are the same signature. Overloads must differ in count or types.
+- **Believing recursion is "elegant" therefore always correct** — elegant code with exponential complexity is still exponentially slow. Verify the recurrence's complexity before celebrating.
+
+</details>
+
+## Reference: how to run a topic file
+
+<details>
+<summary>Java / Python / C++ / Rust / Web one-liners</summary>
+
 
 From the week's directory:
 
@@ -46,40 +130,10 @@ open web/<file>.html   # macOS
 xdg-open web/<file>.html   # Linux
 ```
 
-## Topic roadmap
-
-- **1. MethodBasics**
-- **2. MethodOverloading**
-- **3. RecursionBasics**
-- **4. FibonacciRecursion**
-- **5. TowerOfHanoi**
-- **6. RecursionPatterns**
-
-## Tradeoff Matrix
-
-Flagship topic: solving the Tower of Hanoi (recursion).
-
-| Approach | Time | Space | Code complexity | When to prefer |
-|----------|------|-------|-----------------|----------------|
-| Classic recursion (move n-1, move 1, move n-1) | O(2ⁿ) | O(n) stack | Low | The canonical solution — clearest expression of the recurrence |
-| Iterative (binary counter / Frame–Stewart) | O(2ⁿ) | O(1) | High | When stack depth is a real concern |
-| Bitwise enumeration of moves | O(2ⁿ) | O(1) | High | Curiosity / understanding the move sequence |
-
-| Approach (Fibonacci recursion) | Time | Space | Code complexity | When to prefer |
-|----------|------|-------|-----------------|----------------|
-| Plain recursion | O(φⁿ) | O(n) | Low | Pedagogy only |
-| Memoized recursion | O(n) | O(n) | Medium | When you also need a recursion-shaped solution |
-| Tail-recursion-style iteration | O(n) | O(1) | Low | Production |
-
-## Anti-patterns to avoid
-
-- **Calling a recursive method without a base case** — the first recursive call you write should immediately return on the smallest input. Without that, you get StackOverflowError instantly.
-- **Putting the base case after the recursive call** — order matters. The check must run *before* recursing, or you recurse one extra level into invalid input.
-- **Confusing "what the function returns" with "what it prints"** — pick one contract per method. Methods that both print and return are hard to test and hard to compose.
-- **Method overloading by argument *order* of the same types** — `foo(int a, int b)` and `foo(int b, int a)` are the same signature. Overloads must differ in count or types.
-- **Believing recursion is "elegant" therefore always correct** — elegant code with exponential complexity is still exponentially slow. Verify the recurrence's complexity before celebrating.
+</details>
 
 ## Reflection prompts
+
 
 - Which topic this week was hardest, and what made it hard?
 - Was there a pattern you didn't recognize and had to be told about? Which one?

--- a/Week 6/README.md
+++ b/Week 6/README.md
@@ -1,10 +1,40 @@
-# Week 6
+# Week 6 — Arrays
 
-> Self-check: `./scripts/journey quiz 6` — run the mastery checkpoints for this week.
+> Self-check: `./scripts/journey quiz 6`  |  Next session: `./scripts/journey next`
 
-Each topic is implemented in all five languages: **Java, Python, C++, Rust, and Web (HTML/JS)**. The Java track is the primary detailed walkthrough; the others mirror it with idiomatic constructs.
+## Today's session (~45 min)
 
-## Topic index
+1. **Concept** (10 min) — Read [`python/4.prefix_sum_and_kadane.py`](python/4.prefix_sum_and_kadane.py) (CONCEPT + KEY POINTS blocks).
+2. **Recognize the pattern** (5 min) — Try drills 1-5 in [`patterns.md`](patterns.md) cold.
+3. **Implement from spec** (20 min) — Pick Challenge 1 from [`challenges.md`](challenges.md). Code it in `workbook/week_06/attempts/`.
+4. **Verify YOUR code** (5 min) — `./scripts/journey verify kadane_max_subarray workbook/week_06/attempts/<your-file>.py`
+5. **Mastery quiz** (5 min) — `./scripts/journey quiz 6`
+
+If you got stuck: open [`python/4.prefix_sum_and_kadane.py`](python/4.prefix_sum_and_kadane.py) and diff against your attempt.
+If you finish early: drills 6-10 in `patterns.md`, or Challenge 2.
+
+**Primary language: Python.** Want to compare implementations? See the per-language table below.
+
+---
+
+## Topic overview
+
+This week covers **Arrays**. You'll touch: ReturnArraySum, LinearSearch, ArrayReverseAndRotate, PrefixSumAndKadane, DutchNationalFlagAndMissing. The flagship algorithm/concept for the week is implemented in all five languages, and the Python file listed in Today's session is the canonical walkthrough.
+
+## Related materials
+
+| Resource | Use it when |
+|----------|-------------|
+| Mock interview: [`mock_interviews/01_two_sum_warm_up.md`](../mock_interviews/01_two_sum_warm_up.md) | Hashing/array two-sum style problems in a conversation |
+| [`problems.md`](problems.md) | You want extra practice with company-tagged problems |
+
+## Reference: per-language topic index
+
+<details>
+<summary>All implementations (Java / Python / C++ / Rust / Web)</summary>
+
+**Topic index**
+
 
 | # | Topic | Java | Python | C++ | Rust | Web |
 |---|-------|------|--------|-----|------|-----|
@@ -14,7 +44,8 @@ Each topic is implemented in all five languages: **Java, Python, C++, Rust, and 
 | 4 | PrefixSumAndKadane | `java/4.PrefixSumAndKadane.java` | `python/4.prefix_sum_and_kadane.py` | `cpp/4.prefix_sum_and_kadane.cpp` | `rust/s04_prefix_sum_and_kadane.rs` | `web/4.prefix_sum_and_kadane.html` |
 | 5 | DutchNationalFlagAndMissing | `java/5.DutchNationalFlagAndMissing.java` | `python/5.dutch_national_flag_and_missing.py` | `cpp/5.dutch_national_flag_and_missing.cpp` | `rust/s05_dutch_national_flag_and_missing.rs` | `web/5.dutch_national_flag_and_missing.html` |
 
-## Survey companions
+**Survey companions**
+
 
 Cross-cutting files that summarize the week or provide an interactive overview:
 
@@ -23,7 +54,59 @@ Cross-cutting files that summarize the week or provide an interactive overview:
 | Arrays | — | `python/arrays.py` | `cpp/arrays.cpp` | `rust/arrays.rs` | — |
 | Interactive index | — | — | — | — | `web/index.html` |
 
-## How to run a topic file
+**Topic roadmap**
+
+
+- **1. ReturnArraySum**
+- **2. LinearSearch**
+- **3. ArrayReverseAndRotate**
+- **4. PrefixSumAndKadane**
+- **5. DutchNationalFlagAndMissing**
+
+</details>
+
+## Reference: tradeoff matrix
+
+<details>
+<summary>Approach x Time x Space x When-to-prefer</summary>
+
+
+Flagship topic: Maximum Subarray Sum (covered in PrefixSumAndKadane).
+
+| Approach | Time | Space | Code complexity | When to prefer |
+|----------|------|-------|-----------------|----------------|
+| Brute force (all pairs) | O(N²) | O(1) | Low | N ≤ 10³, or as a sanity oracle |
+| Divide & conquer | O(N log N) | O(log N) | Medium | When recursion is required for pedagogy |
+| Kadane's algorithm | O(N) | O(1) | Low | Always — this is the right answer |
+| Prefix sum + running min | O(N) | O(N) | Low | When you also need range-sum queries later |
+
+| Approach (Dutch National Flag) | Time | Space | Code complexity | When to prefer |
+|----------|------|-------|-----------------|----------------|
+| Two passes counting | O(N) | O(1) | Low | When stability is irrelevant |
+| Sort | O(N log N) | O(1) | Low | If sorting library is already in use |
+| Three-pointer in-place | O(N) | O(1) | Medium | When you need a single pass and constant extra space |
+
+</details>
+
+## Reference: anti-patterns to avoid
+
+<details>
+<summary>Common mistakes specific to this week's topic</summary>
+
+
+- **Resetting Kadane's running sum to 0 instead of `max(0, sum + a[i])`** — if all numbers are negative, the "reset to 0" version returns 0 instead of the largest (least-negative) element. Initialize `best = a[0]` and don't reset.
+- **Rotating an array by `k` with `k` separate single-shifts** — that's O(N·k). Use the reverse-three-times trick (reverse all, reverse first k, reverse rest) for O(N) and no extra memory.
+- **Using `array.length()` instead of `array.length`** — arrays use the field `length`, not a method. Strings and collections use methods. Mixing them is the most common Java syntax error in this section.
+- **Finding the "missing number" with a HashSet** — works but uses O(N) memory. The Gauss sum (`n(n+1)/2 − Σa[i]`) or XOR trick (`x ^ x = 0`) does it in O(1) extra space.
+- **Mutating an array while iterating with an enhanced-for** — the iterator's view of the array doesn't update for primitive arrays the way you might expect; for collections it throws ConcurrentModificationException. Use an index-based loop when you need to mutate.
+
+</details>
+
+## Reference: how to run a topic file
+
+<details>
+<summary>Java / Python / C++ / Rust / Web one-liners</summary>
+
 
 From the week's directory:
 
@@ -45,40 +128,10 @@ open web/<file>.html   # macOS
 xdg-open web/<file>.html   # Linux
 ```
 
-## Topic roadmap
-
-- **1. ReturnArraySum**
-- **2. LinearSearch**
-- **3. ArrayReverseAndRotate**
-- **4. PrefixSumAndKadane**
-- **5. DutchNationalFlagAndMissing**
-
-## Tradeoff Matrix
-
-Flagship topic: Maximum Subarray Sum (covered in PrefixSumAndKadane).
-
-| Approach | Time | Space | Code complexity | When to prefer |
-|----------|------|-------|-----------------|----------------|
-| Brute force (all pairs) | O(N²) | O(1) | Low | N ≤ 10³, or as a sanity oracle |
-| Divide & conquer | O(N log N) | O(log N) | Medium | When recursion is required for pedagogy |
-| Kadane's algorithm | O(N) | O(1) | Low | Always — this is the right answer |
-| Prefix sum + running min | O(N) | O(N) | Low | When you also need range-sum queries later |
-
-| Approach (Dutch National Flag) | Time | Space | Code complexity | When to prefer |
-|----------|------|-------|-----------------|----------------|
-| Two passes counting | O(N) | O(1) | Low | When stability is irrelevant |
-| Sort | O(N log N) | O(1) | Low | If sorting library is already in use |
-| Three-pointer in-place | O(N) | O(1) | Medium | When you need a single pass and constant extra space |
-
-## Anti-patterns to avoid
-
-- **Resetting Kadane's running sum to 0 instead of `max(0, sum + a[i])`** — if all numbers are negative, the "reset to 0" version returns 0 instead of the largest (least-negative) element. Initialize `best = a[0]` and don't reset.
-- **Rotating an array by `k` with `k` separate single-shifts** — that's O(N·k). Use the reverse-three-times trick (reverse all, reverse first k, reverse rest) for O(N) and no extra memory.
-- **Using `array.length()` instead of `array.length`** — arrays use the field `length`, not a method. Strings and collections use methods. Mixing them is the most common Java syntax error in this section.
-- **Finding the "missing number" with a HashSet** — works but uses O(N) memory. The Gauss sum (`n(n+1)/2 − Σa[i]`) or XOR trick (`x ^ x = 0`) does it in O(1) extra space.
-- **Mutating an array while iterating with an enhanced-for** — the iterator's view of the array doesn't update for primitive arrays the way you might expect; for collections it throws ConcurrentModificationException. Use an index-based loop when you need to mutate.
+</details>
 
 ## Reflection prompts
+
 
 - Which topic this week was hardest, and what made it hard?
 - Was there a pattern you didn't recognize and had to be told about? Which one?

--- a/Week 7/README.md
+++ b/Week 7/README.md
@@ -1,10 +1,39 @@
-# Week 7
+# Week 7 — Strings
 
-> Self-check: `./scripts/journey quiz 7` — run the mastery checkpoints for this week.
+> Self-check: `./scripts/journey quiz 7`  |  Next session: `./scripts/journey next`
 
-Each topic is implemented in all five languages: **Java, Python, C++, Rust, and Web (HTML/JS)**. The Java track is the primary detailed walkthrough; the others mirror it with idiomatic constructs.
+## Today's session (~45 min)
 
-## Topic index
+1. **Concept** (10 min) — Read [`python/2.palindrome_and_anagram.py`](python/2.palindrome_and_anagram.py) (CONCEPT + KEY POINTS blocks).
+2. **Recognize the pattern** (5 min) — Try drills 1-5 in [`patterns.md`](patterns.md) cold.
+3. **Implement from spec** (20 min) — Pick Challenge 1 from [`challenges.md`](challenges.md). Code it in `workbook/week_07/attempts/`.
+4. **Verify YOUR code** (5 min) — `./scripts/journey verify palindrome_check workbook/week_07/attempts/<your-file>.py`
+5. **Mastery quiz** (5 min) — `./scripts/journey quiz 7`
+
+If you got stuck: open [`python/2.palindrome_and_anagram.py`](python/2.palindrome_and_anagram.py) and diff against your attempt.
+If you finish early: drills 6-10 in `patterns.md`, or Challenge 2.
+
+**Primary language: Python.** Want to compare implementations? See the per-language table below.
+
+---
+
+## Topic overview
+
+This week covers **Strings**. You'll touch: StringBasics, PalindromeAndAnagram, KMPSearch. The flagship algorithm/concept for the week is implemented in all five languages, and the Python file listed in Today's session is the canonical walkthrough.
+
+## Related materials
+
+| Resource | Use it when |
+|----------|-------------|
+| [`problems.md`](problems.md) | You want extra practice with company-tagged problems |
+
+## Reference: per-language topic index
+
+<details>
+<summary>All implementations (Java / Python / C++ / Rust / Web)</summary>
+
+**Topic index**
+
 
 | # | Topic | Java | Python | C++ | Rust | Web |
 |---|-------|------|--------|-----|------|-----|
@@ -12,7 +41,8 @@ Each topic is implemented in all five languages: **Java, Python, C++, Rust, and 
 | 2 | PalindromeAndAnagram | `java/2.PalindromeAndAnagram.java` | `python/2.palindrome_and_anagram.py` | `cpp/2.palindrome_and_anagram.cpp` | `rust/s02_palindrome_and_anagram.rs` | `web/2.palindrome_and_anagram.html` |
 | 3 | KMPSearch | `java/3.KMPSearch.java` | `python/3.kmp_search.py` | `cpp/3.kmp_search.cpp` | `rust/s03_kmp_search.rs` | `web/3.kmp_search.html` |
 
-## Survey companions
+**Survey companions**
+
 
 Cross-cutting files that summarize the week or provide an interactive overview:
 
@@ -21,7 +51,58 @@ Cross-cutting files that summarize the week or provide an interactive overview:
 | Strings | — | `python/strings.py` | `cpp/strings.cpp` | `rust/strings.rs` | — |
 | Interactive index | — | — | — | — | `web/index.html` |
 
-## How to run a topic file
+**Topic roadmap**
+
+
+- **1. StringBasics**
+- **2. PalindromeAndAnagram**
+- **3. KMPSearch**
+
+</details>
+
+## Reference: tradeoff matrix
+
+<details>
+<summary>Approach x Time x Space x When-to-prefer</summary>
+
+
+Flagship topic: substring search (covered in KMPSearch).
+
+| Approach | Time | Space | Code complexity | When to prefer |
+|----------|------|-------|-----------------|----------------|
+| Naive `indexOf` loop | O(N·M) | O(1) | Low | Small patterns / texts, one-off scripts |
+| KMP (failure function) | O(N + M) | O(M) | Medium | Single pattern, worst-case guarantees needed |
+| Rabin–Karp (rolling hash) | O(N + M) avg, O(N·M) worst | O(1) | Medium | Multiple patterns of same length, plagiarism-style checks |
+| Z-algorithm | O(N + M) | O(N + M) | Medium | When you need all match positions and prefix info |
+| Suffix automaton / Aho–Corasick | O(N + M) | O(M·Σ) | High | Many patterns at once |
+
+| Approach (palindrome check) | Time | Space | Code complexity | When to prefer |
+|----------|------|-------|-----------------|----------------|
+| Reverse and compare | O(N) | O(N) | Low | Quick prototype |
+| Two pointers from ends | O(N) | O(1) | Low | Default |
+| Recursion | O(N) | O(N) stack | Medium | Pedagogy |
+
+</details>
+
+## Reference: anti-patterns to avoid
+
+<details>
+<summary>Common mistakes specific to this week's topic</summary>
+
+
+- **Comparing Strings with `==`** — `"abc" == "abc"` can be `true` due to interning, but `s1 == s2` where one was built dynamically is almost always `false`. Use `.equals()` or `.equalsIgnoreCase()`.
+- **Building strings with `+=` inside a loop** — O(N²) due to immutability. Use `StringBuilder` for anything beyond a handful of concatenations.
+- **Checking anagrams with `Arrays.sort(s.toCharArray())` and comparing toString** — `.toString()` on a `char[]` gives you the address, not the contents. Use `new String(arr)` or `Arrays.equals`.
+- **Implementing KMP and reusing `i` for both text and pattern indices** — KMP needs two distinct indices that advance differently on mismatch. Conflating them produces an algorithm that works on examples but fails on patterns with repeated prefixes (the whole point of KMP).
+- **Forgetting Unicode** — `s.length()` returns code units, not code points. Emoji and surrogate pairs will break a naive palindrome check; use `codePointAt` or `Character.toChars` for full Unicode correctness.
+
+</details>
+
+## Reference: how to run a topic file
+
+<details>
+<summary>Java / Python / C++ / Rust / Web one-liners</summary>
+
 
 From the week's directory:
 
@@ -43,39 +124,10 @@ open web/<file>.html   # macOS
 xdg-open web/<file>.html   # Linux
 ```
 
-## Topic roadmap
-
-- **1. StringBasics**
-- **2. PalindromeAndAnagram**
-- **3. KMPSearch**
-
-## Tradeoff Matrix
-
-Flagship topic: substring search (covered in KMPSearch).
-
-| Approach | Time | Space | Code complexity | When to prefer |
-|----------|------|-------|-----------------|----------------|
-| Naive `indexOf` loop | O(N·M) | O(1) | Low | Small patterns / texts, one-off scripts |
-| KMP (failure function) | O(N + M) | O(M) | Medium | Single pattern, worst-case guarantees needed |
-| Rabin–Karp (rolling hash) | O(N + M) avg, O(N·M) worst | O(1) | Medium | Multiple patterns of same length, plagiarism-style checks |
-| Z-algorithm | O(N + M) | O(N + M) | Medium | When you need all match positions and prefix info |
-| Suffix automaton / Aho–Corasick | O(N + M) | O(M·Σ) | High | Many patterns at once |
-
-| Approach (palindrome check) | Time | Space | Code complexity | When to prefer |
-|----------|------|-------|-----------------|----------------|
-| Reverse and compare | O(N) | O(N) | Low | Quick prototype |
-| Two pointers from ends | O(N) | O(1) | Low | Default |
-| Recursion | O(N) | O(N) stack | Medium | Pedagogy |
-
-## Anti-patterns to avoid
-
-- **Comparing Strings with `==`** — `"abc" == "abc"` can be `true` due to interning, but `s1 == s2` where one was built dynamically is almost always `false`. Use `.equals()` or `.equalsIgnoreCase()`.
-- **Building strings with `+=` inside a loop** — O(N²) due to immutability. Use `StringBuilder` for anything beyond a handful of concatenations.
-- **Checking anagrams with `Arrays.sort(s.toCharArray())` and comparing toString** — `.toString()` on a `char[]` gives you the address, not the contents. Use `new String(arr)` or `Arrays.equals`.
-- **Implementing KMP and reusing `i` for both text and pattern indices** — KMP needs two distinct indices that advance differently on mismatch. Conflating them produces an algorithm that works on examples but fails on patterns with repeated prefixes (the whole point of KMP).
-- **Forgetting Unicode** — `s.length()` returns code units, not code points. Emoji and surrogate pairs will break a naive palindrome check; use `codePointAt` or `Character.toChars` for full Unicode correctness.
+</details>
 
 ## Reflection prompts
+
 
 - Which topic this week was hardest, and what made it hard?
 - Was there a pattern you didn't recognize and had to be told about? Which one?

--- a/Week 8/README.md
+++ b/Week 8/README.md
@@ -1,17 +1,49 @@
-# Week 8
+# Week 8 — Searching Algorithms
 
-> Self-check: `./scripts/journey quiz 8` — run the mastery checkpoints for this week.
+> Self-check: `./scripts/journey quiz 8`  |  Next session: `./scripts/journey next`
 
-Each topic is implemented in all five languages: **Java, Python, C++, Rust, and Web (HTML/JS)**. The Java track is the primary detailed walkthrough; the others mirror it with idiomatic constructs.
+## Today's session (~45 min)
 
-## Topic index
+1. **Concept** (10 min) — Read [`python/1.binary_search.py`](python/1.binary_search.py) (CONCEPT + KEY POINTS blocks).
+2. **Recognize the pattern** (5 min) — Try drills 1-5 in [`patterns.md`](patterns.md) cold.
+3. **Implement from spec** (20 min) — Pick Challenge 1 from [`challenges.md`](challenges.md). Code it in `workbook/week_08/attempts/`.
+4. **Verify YOUR code** (5 min) — `./scripts/journey verify binary_search workbook/week_08/attempts/<your-file>.py`
+5. **Mastery quiz** (5 min) — `./scripts/journey quiz 8`
+
+If you got stuck: open [`python/1.binary_search.py`](python/1.binary_search.py) and diff against your attempt.
+If you finish early: drills 6-10 in `patterns.md`, or Challenge 2.
+
+**Primary language: Python.** Want to compare implementations? See the per-language table below.
+
+---
+
+## Topic overview
+
+This week covers **Searching Algorithms**. You'll touch: BinarySearch, BinarySearchOnAnswer. The flagship algorithm/concept for the week is implemented in all five languages, and the Python file listed in Today's session is the canonical walkthrough.
+
+## Related materials
+
+| Resource | Use it when |
+|----------|-------------|
+| Visualization: [`viz/binary_search.html`](../viz/binary_search.html) | You want to SEE the search bounds collapse step by step |
+| Mock interview: [`mock_interviews/01_two_sum_warm_up.md`](../mock_interviews/01_two_sum_warm_up.md) | Searching/array problems discussed conversationally |
+| [`problems.md`](problems.md) | You want extra practice with company-tagged problems |
+
+## Reference: per-language topic index
+
+<details>
+<summary>All implementations (Java / Python / C++ / Rust / Web)</summary>
+
+**Topic index**
+
 
 | # | Topic | Java | Python | C++ | Rust | Web |
 |---|-------|------|--------|-----|------|-----|
 | 1 | BinarySearch | `java/1.BinarySearch.java` | `python/1.binary_search.py` | `cpp/1.binary_search.cpp` | `rust/s01_binary_search.rs` | `web/1.binary_search.html` |
 | 2 | BinarySearchOnAnswer | `java/2.BinarySearchOnAnswer.java` | `python/2.binary_search_on_answer.py` | `cpp/2.binary_search_on_answer.cpp` | `rust/s02_binary_search_on_answer.rs` | `web/2.binary_search_on_answer.html` |
 
-## Survey companions
+**Survey companions**
+
 
 Cross-cutting files that summarize the week or provide an interactive overview:
 
@@ -20,7 +52,51 @@ Cross-cutting files that summarize the week or provide an interactive overview:
 | Searching | — | `python/searching.py` | `cpp/searching.cpp` | `rust/searching.rs` | — |
 | Interactive index | — | — | — | — | `web/index.html` |
 
-## How to run a topic file
+**Topic roadmap**
+
+
+- **1. BinarySearch**
+- **2. BinarySearchOnAnswer**
+
+</details>
+
+## Reference: tradeoff matrix
+
+<details>
+<summary>Approach x Time x Space x When-to-prefer</summary>
+
+
+Flagship topic: Binary Search (plain and on the answer).
+
+| Approach | Time | Space | Code complexity | When to prefer |
+|----------|------|-------|-----------------|----------------|
+| Linear scan | O(N) | O(1) | Low | N ≤ 10³, or unsorted data |
+| Standard binary search | O(log N) | O(1) | Low | Sorted array, find exact match |
+| Lower / upper bound (search-for-boundary) | O(log N) | O(1) | Medium | Find first/last position of a value or first index satisfying a predicate |
+| Binary search on answer | O(log(range) · check) | O(1) | Medium | Monotonic-feasibility problems (capacity, min/max threshold) |
+| Exponential / galloping search | O(log N) | O(1) | Medium | Unbounded arrays, or when the target is near the front |
+
+</details>
+
+## Reference: anti-patterns to avoid
+
+<details>
+<summary>Common mistakes specific to this week's topic</summary>
+
+
+- **`mid = (lo + hi) / 2` overflow** — for large `int` values `lo + hi` overflows. Use `lo + (hi - lo) / 2` instead. Trips you up exactly when the input is large enough to matter.
+- **Mixing `lo <= hi` with `hi = mid` updates** — those two patterns lead to infinite loops. Choose one invariant and stick: either inclusive bounds with `mid ± 1` updates, or half-open with `hi = mid`.
+- **Binary searching on unsorted data** — the precondition is non-negotiable. If your data isn't sorted on the key you're searching, binary search returns nonsense without erroring.
+- **Forgetting to verify "answer is monotonic" before binary-searching on answer** — the predicate must be monotone (all `false`s then all `true`s). If it isn't, you're using binary search on a non-bisectable function and the result is undefined.
+- **Returning `mid` immediately when finding the *first* occurrence** — for first/last occurrence you must keep searching the relevant half even after a hit. Returning early gives "an" occurrence, not "the first" one.
+
+</details>
+
+## Reference: how to run a topic file
+
+<details>
+<summary>Java / Python / C++ / Rust / Web one-liners</summary>
+
 
 From the week's directory:
 
@@ -42,32 +118,10 @@ open web/<file>.html   # macOS
 xdg-open web/<file>.html   # Linux
 ```
 
-## Topic roadmap
-
-- **1. BinarySearch**
-- **2. BinarySearchOnAnswer**
-
-## Tradeoff Matrix
-
-Flagship topic: Binary Search (plain and on the answer).
-
-| Approach | Time | Space | Code complexity | When to prefer |
-|----------|------|-------|-----------------|----------------|
-| Linear scan | O(N) | O(1) | Low | N ≤ 10³, or unsorted data |
-| Standard binary search | O(log N) | O(1) | Low | Sorted array, find exact match |
-| Lower / upper bound (search-for-boundary) | O(log N) | O(1) | Medium | Find first/last position of a value or first index satisfying a predicate |
-| Binary search on answer | O(log(range) · check) | O(1) | Medium | Monotonic-feasibility problems (capacity, min/max threshold) |
-| Exponential / galloping search | O(log N) | O(1) | Medium | Unbounded arrays, or when the target is near the front |
-
-## Anti-patterns to avoid
-
-- **`mid = (lo + hi) / 2` overflow** — for large `int` values `lo + hi` overflows. Use `lo + (hi - lo) / 2` instead. Trips you up exactly when the input is large enough to matter.
-- **Mixing `lo <= hi` with `hi = mid` updates** — those two patterns lead to infinite loops. Choose one invariant and stick: either inclusive bounds with `mid ± 1` updates, or half-open with `hi = mid`.
-- **Binary searching on unsorted data** — the precondition is non-negotiable. If your data isn't sorted on the key you're searching, binary search returns nonsense without erroring.
-- **Forgetting to verify "answer is monotonic" before binary-searching on answer** — the predicate must be monotone (all `false`s then all `true`s). If it isn't, you're using binary search on a non-bisectable function and the result is undefined.
-- **Returning `mid` immediately when finding the *first* occurrence** — for first/last occurrence you must keep searching the relevant half even after a hit. Returning early gives "an" occurrence, not "the first" one.
+</details>
 
 ## Reflection prompts
+
 
 - Which topic this week was hardest, and what made it hard?
 - Was there a pattern you didn't recognize and had to be told about? Which one?

--- a/Week 9/README.md
+++ b/Week 9/README.md
@@ -1,10 +1,41 @@
-# Week 9
+# Week 9 — Sorting Algorithms
 
-> Self-check: `./scripts/journey quiz 9` — run the mastery checkpoints for this week.
+> Self-check: `./scripts/journey quiz 9`  |  Next session: `./scripts/journey next`
 
-Each topic is implemented in all five languages: **Java, Python, C++, Rust, and Web (HTML/JS)**. The Java track is the primary detailed walkthrough; the others mirror it with idiomatic constructs.
+## Today's session (~45 min)
 
-## Topic index
+1. **Concept** (10 min) — Read [`python/2.merge_sort.py`](python/2.merge_sort.py) (CONCEPT + KEY POINTS blocks).
+2. **Recognize the pattern** (5 min) — Try drills 1-5 in [`patterns.md`](patterns.md) cold.
+3. **Implement from spec** (20 min) — Pick Challenge 1 from [`challenges.md`](challenges.md). Code it in `workbook/week_09/attempts/`.
+4. **Verify YOUR code** (5 min) — `./scripts/journey verify merge_sort workbook/week_09/attempts/<your-file>.py`
+5. **Mastery quiz** (5 min) — `./scripts/journey quiz 9`
+
+If you got stuck: open [`python/2.merge_sort.py`](python/2.merge_sort.py) and diff against your attempt.
+If you finish early: drills 6-10 in `patterns.md`, or Challenge 2.
+
+**Primary language: Python.** Want to compare implementations? See the per-language table below.
+
+---
+
+## Topic overview
+
+This week covers **Sorting Algorithms**. You'll touch: BubbleSelectionInsertion, MergeSort, QuickSort. The flagship algorithm/concept for the week is implemented in all five languages, and the Python file listed in Today's session is the canonical walkthrough.
+
+## Related materials
+
+| Resource | Use it when |
+|----------|-------------|
+| Visualization: [`viz/sorts.html`](../viz/sorts.html) | You want to SEE the sorting algorithms in motion |
+| Mock interview: [`mock_interviews/02_meeting_rooms_intervals.md`](../mock_interviews/02_meeting_rooms_intervals.md) | Sorting / interval problems in a conversation |
+| [`problems.md`](problems.md) | You want extra practice with company-tagged problems |
+
+## Reference: per-language topic index
+
+<details>
+<summary>All implementations (Java / Python / C++ / Rust / Web)</summary>
+
+**Topic index**
+
 
 | # | Topic | Java | Python | C++ | Rust | Web |
 |---|-------|------|--------|-----|------|-----|
@@ -12,7 +43,8 @@ Each topic is implemented in all five languages: **Java, Python, C++, Rust, and 
 | 2 | MergeSort | `java/2.MergeSort.java` | `python/2.merge_sort.py` | `cpp/2.merge_sort.cpp` | `rust/s02_merge_sort.rs` | `web/2.merge_sort.html` |
 | 3 | QuickSort | `java/3.QuickSort.java` | `python/3.quick_sort.py` | `cpp/3.quick_sort.cpp` | `rust/s03_quick_sort.rs` | `web/3.quick_sort.html` |
 
-## Survey companions
+**Survey companions**
+
 
 Cross-cutting files that summarize the week or provide an interactive overview:
 
@@ -21,7 +53,53 @@ Cross-cutting files that summarize the week or provide an interactive overview:
 | Sorting | — | `python/sorting.py` | `cpp/sorting.cpp` | `rust/sorting.rs` | — |
 | Interactive index | — | — | — | — | `web/index.html` |
 
-## How to run a topic file
+**Topic roadmap**
+
+
+- **1. BubbleSelectionInsertion**
+- **2. MergeSort**
+- **3. QuickSort**
+
+</details>
+
+## Reference: tradeoff matrix
+
+<details>
+<summary>Approach x Time x Space x When-to-prefer</summary>
+
+
+Flagship topic: sorting algorithms (Bubble / Selection / Insertion / Merge / Quick).
+
+| Approach | Time (avg) | Time (worst) | Space | Stable? | When to prefer |
+|----------|------|------|-------|---------|----------------|
+| Bubble sort | O(N²) | O(N²) | O(1) | Yes | Teaching only — never in production |
+| Selection sort | O(N²) | O(N²) | O(1) | No | When writes are expensive (minimizes swaps) |
+| Insertion sort | O(N²) | O(N²) | O(1) | Yes | Nearly-sorted data, small N (~16), inner loop of hybrid sorts |
+| Merge sort | O(N log N) | O(N log N) | O(N) | Yes | Stability matters, linked lists, external sorting |
+| Quick sort (random pivot) | O(N log N) | O(N²) | O(log N) | No | General-purpose in-memory, cache-friendly |
+| Heap sort | O(N log N) | O(N log N) | O(1) | No | Worst-case guarantees with O(1) space |
+
+</details>
+
+## Reference: anti-patterns to avoid
+
+<details>
+<summary>Common mistakes specific to this week's topic</summary>
+
+
+- **Picking the first or last element as quicksort pivot on sorted input** — degrades to O(N²). Randomize or use median-of-three to defeat adversarial inputs.
+- **Treating merge sort's "merge" as the hard part and sloppily slicing arrays** — repeatedly copying sub-arrays turns O(N log N) memory into O(N²). Pass index ranges, not new arrays.
+- **Believing "stable" means "fast"** — stability is about preserving order of equal keys, nothing about speed. Quick sort is faster than merge sort on average yet unstable.
+- **Sorting a `List<Integer>` and assuming primitive performance** — boxing/unboxing adds significant overhead and breaks cache locality. Use `int[]` and `Arrays.sort` when performance matters.
+- **Calling `Arrays.sort` on primitive arrays expecting a stable sort** — Java's `Arrays.sort(int[])` uses dual-pivot quicksort and is *not* stable. `Arrays.sort(Object[])` uses TimSort and *is* stable.
+
+</details>
+
+## Reference: how to run a topic file
+
+<details>
+<summary>Java / Python / C++ / Rust / Web one-liners</summary>
+
 
 From the week's directory:
 
@@ -43,34 +121,10 @@ open web/<file>.html   # macOS
 xdg-open web/<file>.html   # Linux
 ```
 
-## Topic roadmap
-
-- **1. BubbleSelectionInsertion**
-- **2. MergeSort**
-- **3. QuickSort**
-
-## Tradeoff Matrix
-
-Flagship topic: sorting algorithms (Bubble / Selection / Insertion / Merge / Quick).
-
-| Approach | Time (avg) | Time (worst) | Space | Stable? | When to prefer |
-|----------|------|------|-------|---------|----------------|
-| Bubble sort | O(N²) | O(N²) | O(1) | Yes | Teaching only — never in production |
-| Selection sort | O(N²) | O(N²) | O(1) | No | When writes are expensive (minimizes swaps) |
-| Insertion sort | O(N²) | O(N²) | O(1) | Yes | Nearly-sorted data, small N (~16), inner loop of hybrid sorts |
-| Merge sort | O(N log N) | O(N log N) | O(N) | Yes | Stability matters, linked lists, external sorting |
-| Quick sort (random pivot) | O(N log N) | O(N²) | O(log N) | No | General-purpose in-memory, cache-friendly |
-| Heap sort | O(N log N) | O(N log N) | O(1) | No | Worst-case guarantees with O(1) space |
-
-## Anti-patterns to avoid
-
-- **Picking the first or last element as quicksort pivot on sorted input** — degrades to O(N²). Randomize or use median-of-three to defeat adversarial inputs.
-- **Treating merge sort's "merge" as the hard part and sloppily slicing arrays** — repeatedly copying sub-arrays turns O(N log N) memory into O(N²). Pass index ranges, not new arrays.
-- **Believing "stable" means "fast"** — stability is about preserving order of equal keys, nothing about speed. Quick sort is faster than merge sort on average yet unstable.
-- **Sorting a `List<Integer>` and assuming primitive performance** — boxing/unboxing adds significant overhead and breaks cache locality. Use `int[]` and `Arrays.sort` when performance matters.
-- **Calling `Arrays.sort` on primitive arrays expecting a stable sort** — Java's `Arrays.sort(int[])` uses dual-pivot quicksort and is *not* stable. `Arrays.sort(Object[])` uses TimSort and *is* stable.
+</details>
 
 ## Reflection prompts
+
 
 - Which topic this week was hardest, and what made it hard?
 - Was there a pattern you didn't recognize and had to be told about? Which one?

--- a/docs/JOURNEY_CLI.md
+++ b/docs/JOURNEY_CLI.md
@@ -1,0 +1,292 @@
+# The `journey` CLI — full reference
+
+`./scripts/journey` is the single entry point for the daily learning loop:
+onboarding, picking a next session, scaffolding code, verifying it, journaling,
+spaced-repetition review, and progress tracking.
+
+```bash
+./scripts/journey --help
+```
+
+State lives in `~/.journey/`:
+
+| File | Purpose |
+|------|---------|
+| `config.json` | Your preferences: language, time-per-session, goal, soft-gate flag. |
+| `progress.json` | Per-week quiz results, FSRS state, rolling history, miss counts. |
+| `dashboard.html` | Self-contained HTML written by `progress --html` / `dashboard`. |
+
+> Set `JOURNEY_NON_INTERACTIVE=1` to make every command auto-pick defaults — the
+> CI workflow and smoke tests rely on this.
+
+---
+
+## `start` — onboarding
+
+```bash
+./scripts/journey start
+```
+
+Walks four short prompts (≈2 minutes total):
+
+1. Primary language? `python` / `java` / `cpp` / `rust` (default `python`)
+2. Time per session? `15m` / `30m` / `1h` (default `30m`)
+3. Goal? `interview` / `curriculum` / `exploration` (default `curriculum`)
+4. Skip the diagnostic? `y/N` — answering "no" surfaces a one-line pointer to
+   `docs/diagnostic.md` and prints the current progress table.
+
+Persists answers to `~/.journey/config.json` with `soft_gate_enabled: true`.
+With `JOURNEY_NON_INTERACTIVE=1` it accepts every default silently.
+
+---
+
+## `next` — pick ONE concrete next action
+
+```bash
+./scripts/journey next                  # 30 min plan
+./scripts/journey next --time 15m       # smaller plan (one task)
+./scripts/journey next --time 1h        # full session (4 tasks)
+./scripts/journey next --time weekend   # capstone-sized
+./scripts/journey next --skip           # advance current_week without doing it
+./scripts/journey next --skip --force   # override the soft mastery gate
+```
+
+Decision logic (priority order):
+
+1. No progress AND no config → recommend `./scripts/journey start`.
+2. Current week's mastery < 80% → suggest a mastery-quiz-focused session.
+3. Else if there are FSRS-due skills AND time ≥ 15m → suggest `review`.
+4. Else suggest the *next* week's first session (concept + drill + implement + verify).
+
+Output is a numbered plan with explicit `Open:` / `Run:` commands so there's
+zero ambiguity about what to do.
+
+### Time scaling
+
+| `--time` | Plan size |
+|----------|-----------|
+| `15m`    | ONE small task (a drill or a concept skim) |
+| `30m`    | 3 tasks (concept + drill + quiz verification) |
+| `1h`     | 4-5 tasks (concept + drill + implement + verify + quiz) |
+| `weekend` | Capstone-scale: multi-step sprint, optionally a capstone milestone |
+
+### Soft mastery gate
+
+If `soft_gate_enabled` is true (the default) and your current week's mastery
+quiz is below 80%, `next` will refuse to jump ahead — pass `--force` to
+override. This prevents the "always-rush-forward" failure mode.
+
+---
+
+## `quiz` — mastery checkpoints for a week
+
+```bash
+./scripts/journey quiz 6              # full Week 6 quiz
+./scripts/journey quiz 6 --n 3        # 3 random questions
+./scripts/journey quiz 6 --review     # 80% Week 6 + 20% FSRS-due
+./scripts/journey quiz all            # 10 random questions across all weeks
+```
+
+After each question you can self-rate `again/hard/good/easy` (or press Enter to
+auto-rate). Ratings feed the FSRS scheduler that drives `review` and `next`.
+See [`MASTERY.md`](MASTERY.md) and [`SPACED_REPETITION.md`](SPACED_REPETITION.md)
+for the algorithm.
+
+---
+
+## `review` — only what FSRS says is due
+
+```bash
+./scripts/journey review
+./scripts/journey review --n 5    # cap to 5 skills
+```
+
+Walks every week's `mastery.yml`, picks skills whose `next_review_date` is today
+or earlier, orders them most-overdue-first, and runs them as a single mixed
+quiz. If nothing is due, the command prints a hint and exits cleanly.
+
+---
+
+## `new-attempt` — scaffold a workbook stub
+
+```bash
+./scripts/journey new-attempt kadane             # uses config.language
+./scripts/journey new-attempt two_sum --lang java # one-off override
+```
+
+- Picks the current week from `progress.json`.
+- Creates `workbook/week_NN/attempts/` if needed.
+- Writes `workbook/week_NN/attempts/<topic>__YYYY-MM-DD.<ext>` with:
+  - a header comment (topic, week, date),
+  - the function signature pulled from `tests/cases/<topic>.json`,
+  - a `# WRITE YOUR CODE HERE` block, and
+  - (Python only) an `if __name__ == "__main__":` block with one sample input.
+- If a file with that exact name already exists, the date suffix is bumped
+  (`...-2.py`, `...-3.py`, etc.). Existing attempts are never overwritten.
+
+Topic resolution supports aliases — typing `kadane` finds
+`tests/cases/kadane_max_subarray.json`. See the full alias table in
+`scripts/journey` (`TOPIC_FIXTURE_ALIASES`).
+
+---
+
+## `verify` — run YOUR code against the fixtures
+
+```bash
+./scripts/journey verify kadane workbook/week_06/attempts/kadane__2026-05-12.py
+```
+
+- Resolves the topic to a `tests/cases/<topic>.json` fixture (with alias support).
+- Dynamically imports your file as a Python module.
+- For each case, calls `module.<function>(*input)` and compares to `expected`.
+- Prints `PASS <case>` / `FAIL <case>` with `input / expected / got` diff.
+- Final line: `TOTAL: X/Y passed` and a pointer to `tests/refs/<topic>.py` for
+  the canonical implementation diff.
+- Exits non-zero if any case fails (handy in shell pipelines).
+
+If the topic doesn't exist, the command lists every available topic so you
+know what's testable.
+
+---
+
+## `reflect` — append a journal entry
+
+```bash
+./scripts/journey reflect              # uses current_week
+./scripts/journey reflect --week 6     # specific week
+```
+
+- Creates `workbook/week_NN/journal.md` if missing.
+- Appends a dated section with the **Reflection prompts** parsed from that
+  week's `Week NN/README.md`. Each prompt is followed by a blank `(your
+  thoughts here)` placeholder.
+- Prints the path and the appended template so you know where to write.
+
+The journal is yours — no editor is launched. Just write honest two-sentence
+answers; over 30 weeks they become a high-leverage retrospective artefact.
+
+---
+
+## `daily` — today's deterministic 25-min drip
+
+```bash
+./scripts/journey daily
+./scripts/journey daily --markdown      # for piping into emails / issues
+```
+
+A deterministic plan (driven by today's ordinal day) that mixes:
+
+1. A pattern-recognition drill from the current week's `patterns.md`.
+2. A challenge from a revisit week (N-3 or N-7 per `REVIEW_SCHEDULE.md`).
+3. A mastery-quiz topic from `Week N/mastery.yml`.
+4. A reflection prompt from a curated rotating list.
+
+Use `next` for an adaptive plan; use `daily` if you want the same plan to
+appear regardless of progress state.
+
+---
+
+## `progress` — text table
+
+```bash
+./scripts/journey progress
+```
+
+One row per week: skills tested, pass rate, last attempt timestamp. Ends with
+a "Suggested next" pointer that respects the highest week you've ever quizzed.
+
+```bash
+./scripts/journey progress --html        # writes ~/.journey/dashboard.html
+./scripts/journey progress --html --open # also opens in default browser
+./scripts/journey dashboard              # shortcut for the line above
+```
+
+The HTML dashboard is self-contained (no external CSS/JS) — refresh it
+whenever you want a visual heat-map, streak counter, top-missed-skills table,
+time-to-mastery table, and a recommended next session.
+
+---
+
+## `reset` — forget a week's progress
+
+```bash
+./scripts/journey reset 6
+```
+
+Removes `progress.json["weeks"]["6"]`. FSRS state (`srs_state`) and rolling
+history are preserved — you only zero out the per-week summary.
+
+---
+
+## Default (no subcommand)
+
+```bash
+./scripts/journey
+```
+
+Prints "Resuming at Week N" and runs `progress` so you can see the table at a
+glance. Most users alias this to `j` and run it as the first thing every day.
+
+---
+
+## Configuration schema
+
+`~/.journey/config.json`:
+
+```json
+{
+  "language": "python",
+  "time_per_session": "30m",
+  "goal": "curriculum",
+  "soft_gate_enabled": true
+}
+```
+
+| Key | Values | Effect |
+|-----|--------|--------|
+| `language` | `python` / `java` / `cpp` / `rust` | Default for `new-attempt` stubs. |
+| `time_per_session` | `15m` / `30m` / `1h` / `weekend` | Default for `next` plan size. |
+| `goal` | `interview` / `curriculum` / `exploration` | Soft hint (currently informational). |
+| `soft_gate_enabled` | bool | If true, `next` refuses to advance past current week with <80% mastery (override with `--force`). |
+
+Backwards-compatible with `progress.json`: every command reads both files and
+falls back to sensible defaults if either is missing.
+
+---
+
+## Common workflows
+
+**First-time setup:**
+
+```bash
+./scripts/journey start
+./scripts/journey next
+```
+
+**Every morning (5-10 min):**
+
+```bash
+./scripts/journey review              # FSRS-due skills, if any
+./scripts/journey next --time 15m     # one small task
+```
+
+**Weekly deep dive (1 hour):**
+
+```bash
+./scripts/journey next --time 1h
+# ... do the suggested concept + drill + implement + verify ...
+./scripts/journey quiz N              # confirm mastery
+./scripts/journey reflect             # write 4 short paragraphs
+```
+
+**Weekend capstone:**
+
+```bash
+./scripts/journey next --time weekend
+```
+
+**Track your progress visually:**
+
+```bash
+./scripts/journey dashboard           # opens ~/.journey/dashboard.html
+```

--- a/docs/MASTERY.md
+++ b/docs/MASTERY.md
@@ -121,3 +121,26 @@ Great work — for retention, revisit Week 3 and Week — (see docs/REVIEW_SCHED
 2. Add an entry with a unique `id`, a short `prompt`, the correct `answer` (matching the `type`'s shape), and a one-line `explanation`.
 3. (Optional) Run `./scripts/journey progress` — it parses every `mastery.yml`, so YAML errors will surface immediately.
 4. (Optional) Run `JOURNEY_NON_INTERACTIVE=1 ./scripts/journey quiz N` to confirm the new skill doesn't crash the engine.
+
+---
+
+## What's next?
+
+Mastery quizzes test recognition under time pressure. They don't test whether
+you can actually write the algorithm. Two newer subcommands close that loop:
+
+- **`./scripts/journey next`** — picks ONE concrete next action for your
+  session based on `current_week`, FSRS-due skills, and the time you have
+  (`--time 15m | 30m | 1h | weekend`). Use this as your "what should I work
+  on right now?" button. Honors a soft mastery gate: you'll get a warning if
+  you try to jump ahead before scoring ≥80% on the current week
+  (pass `--force` to override).
+- **`./scripts/journey verify <topic> <file>`** — runs YOUR code against the
+  same fixtures the canonical reference implementations pass. Use it after
+  `./scripts/journey new-attempt <topic>` writes a stub for you in
+  `workbook/week_NN/attempts/`. PASS/FAIL output per case + a pointer to
+  `tests/refs/<topic>.py` for the diff.
+
+The full reference for every subcommand (`start`, `next`, `quiz`, `review`,
+`verify`, `new-attempt`, `reflect`, `daily`, `progress`, `dashboard`,
+`reset`) lives in [`JOURNEY_CLI.md`](JOURNEY_CLI.md).

--- a/scripts/build_all.sh
+++ b/scripts/build_all.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Local smoke test: compile every file in every language.
-# Usage: ./scripts/build_all.sh [python|cpp|rust|java|all|quiz N]
+# Usage: ./scripts/build_all.sh [python|cpp|rust|java|all|quiz N|next [args]]
 set -e
 LANG="${1:-all}"
 
@@ -8,6 +8,12 @@ LANG="${1:-all}"
 if [ "$LANG" = "quiz" ]; then
   shift
   exec "$(dirname "$0")/journey" quiz "$@"
+fi
+
+# Convenience passthrough: `./scripts/build_all.sh next [args]` -> `./scripts/journey next [args]`
+if [ "$LANG" = "next" ]; then
+  shift
+  exec "$(dirname "$0")/journey" next "$@"
 fi
 
 run_python() { find "Week "* -maxdepth 2 -name "*.py" -print0 | xargs -0 -n1 python3 -m py_compile; echo "Python OK"; }

--- a/scripts/journey
+++ b/scripts/journey
@@ -39,8 +39,113 @@ except ImportError:
 REPO_ROOT = Path(__file__).resolve().parent.parent
 PROGRESS_DIR = Path(os.path.expanduser("~/.journey"))
 PROGRESS_FILE = PROGRESS_DIR / "progress.json"
+CONFIG_FILE = PROGRESS_DIR / "config.json"
 TOTAL_WEEKS = 30
 NON_INTERACTIVE = os.environ.get("JOURNEY_NON_INTERACTIVE") == "1"
+
+# Default config used when ~/.journey/config.json doesn't exist yet.
+DEFAULT_CONFIG = {
+    "language": "python",
+    "time_per_session": "30m",
+    "goal": "curriculum",
+    "soft_gate_enabled": True,
+}
+
+# Topic → fixture aliases. Mirror of scripts/coverage_report.py — many topic
+# names a learner might type don't directly match a fixture filename.
+TOPIC_FIXTURE_ALIASES: dict[str, list[str]] = {
+    # Convenient shortcuts a learner might type
+    "kadane": ["kadane_max_subarray"],
+    "prefix_sum": ["kadane_max_subarray"],
+    "dutch_flag": ["dutch_national_flag"],
+    "palindrome": ["palindrome_check"],
+    "anagram": ["valid_anagram"],
+    "spiral": ["spiral_traversal"],
+    "reverse_ll": ["reverse_linked_list"],
+    "linked_list": ["reverse_linked_list"],
+    "lru": ["lru_cache"],
+    "stack": ["balanced_parens"],
+    "queue": ["sliding_window_max"],
+    "bst": ["bst_validate"],
+    "heap": ["kth_largest"],
+    "hashmap": ["two_sum"],
+    "hash_map": ["two_sum"],
+    "topo": ["topological_sort"],
+    "topo_sort": ["topological_sort"],
+    "dp": ["coin_change"],
+    "backtrack": ["n_queens_count"],
+    "n_queens": ["n_queens_count"],
+    "dijkstra": ["dijkstra_shortest_path"],
+    "kruskal": ["kruskal_mst_weight"],
+    "mst": ["kruskal_mst_weight"],
+    "kmp": ["kmp_search"],
+    "rabin_karp": ["rabin_karp_search"],
+    "sliding_window": ["sliding_window_longest_substr"],
+    "binary_search": ["binary_search"],
+    "merge_sort": ["merge_sort"],
+    "quick_sort": ["quick_sort"],
+    "two_sum": ["two_sum"],
+    # The full coverage_report alias table — Java topic stems → fixture(s)
+    "return_array_sum": ["linear_search"],
+    "prefix_sum_and_kadane": ["kadane_max_subarray"],
+    "dutch_national_flag_and_missing": ["dutch_national_flag"],
+    "palindrome_and_anagram": ["palindrome_check", "valid_anagram"],
+    "bubble_selection_insertion": ["quick_sort"],
+    "spiral_and_diagonal_traversal": ["spiral_traversal"],
+    "singly_linked_list": ["reverse_linked_list"],
+    "merge_sorted_lists_and_lru": ["lru_cache"],
+    "stack_implementation": ["balanced_parens"],
+    "queue_implementation": ["sliding_window_max"],
+    "binary_search_tree": ["bst_validate"],
+    "heap_and_priority_queue": ["kth_largest"],
+    "hashing_and_hash_map": ["two_sum"],
+    "graph_representations": ["topological_sort"],
+    "topological_sort": ["topological_sort"],
+    "dynamic_programming": ["coin_change"],
+    "backtracking": ["n_queens_count"],
+    "shortest_paths": ["dijkstra_shortest_path"],
+    "minimum_spanning_tree": ["kruskal_mst_weight"],
+}
+
+
+def load_config() -> dict:
+    """Read ~/.journey/config.json, merged onto DEFAULT_CONFIG."""
+    cfg = dict(DEFAULT_CONFIG)
+    if CONFIG_FILE.exists():
+        try:
+            cfg.update(json.loads(CONFIG_FILE.read_text()))
+        except Exception:
+            pass
+    return cfg
+
+
+def save_config(cfg: dict) -> None:
+    PROGRESS_DIR.mkdir(parents=True, exist_ok=True)
+    CONFIG_FILE.write_text(json.dumps(cfg, indent=2, sort_keys=True))
+
+
+def resolve_topic_fixture(topic: str) -> tuple[str, Path] | None:
+    """Resolve a learner-supplied topic name to (topic_id, fixture_path).
+
+    Tries (in order): direct filename match, alias lookup. Returns None if no
+    fixture is found.
+    """
+    cases_dir = REPO_ROOT / "tests" / "cases"
+    direct = cases_dir / f"{topic}.json"
+    if direct.is_file():
+        return topic, direct
+    for alias in TOPIC_FIXTURE_ALIASES.get(topic, []):
+        candidate = cases_dir / f"{alias}.json"
+        if candidate.is_file():
+            return alias, candidate
+    return None
+
+
+def available_topics() -> list[str]:
+    cases_dir = REPO_ROOT / "tests" / "cases"
+    if not cases_dir.is_dir():
+        return []
+    return sorted(p.stem for p in cases_dir.glob("*.json"))
 
 # ---------------------------------------------------------------------------
 # FSRS (Free Spaced Repetition Scheduler) — minimum viable implementation.
@@ -1311,10 +1416,622 @@ def cmd_review(args: argparse.Namespace) -> int:
 
 
 # ---------------------------------------------------------------------------
+# `next` — pick a single concrete next session
+# ---------------------------------------------------------------------------
+
+TIME_BUDGETS = {
+    "15m": 15,
+    "30m": 30,
+    "1h": 60,
+    "60m": 60,
+    "weekend": 240,
+}
+
+
+def _parse_time(s: str | None) -> int:
+    """Return minutes for a time-budget string. Falls back to 30."""
+    if not s:
+        return 30
+    if s in TIME_BUDGETS:
+        return TIME_BUDGETS[s]
+    # Permit raw numbers like "20" (minutes).
+    try:
+        return max(5, int(s))
+    except ValueError:
+        return 30
+
+
+def _current_week_mastery_rate(progress: dict, week: int) -> float:
+    rec = progress.get("weeks", {}).get(str(week))
+    if not rec:
+        return 0.0
+    return float(rec.get("rate", 0) or 0)
+
+
+def _first_python_topic_file(week: int) -> Path | None:
+    py_dir = REPO_ROOT / f"Week {week}" / "python"
+    if not py_dir.is_dir():
+        return None
+    # Pick a "feature" topic file — first numbered file works.
+    candidates = sorted(
+        p for p in py_dir.iterdir()
+        if p.is_file() and p.suffix == ".py" and re.match(r"^\d+\.", p.name)
+    )
+    if candidates:
+        # Prefer the mid-week file for "flagship" feel.
+        return candidates[min(len(candidates) - 1, 3)]
+    return None
+
+
+def _build_session_steps(week: int, minutes: int, due_count: int) -> list[str]:
+    """Render the numbered step list for a session."""
+    concept_path = _first_python_topic_file(week)
+    rel_concept = (
+        concept_path.relative_to(REPO_ROOT) if concept_path else f"Week {week}/python/"
+    )
+    rel_patterns = f"Week {week}/patterns.md"
+    rel_challenges = f"Week {week}/challenges.md"
+    workbook_dir = f"workbook/week_{week:02d}/attempts/"
+
+    steps: list[str] = []
+    if minutes <= 15:
+        # Just ONE small task. Pick the highest-leverage thing.
+        steps.append(
+            f"1. Drill (10 min)\n"
+            f"   Open: {rel_patterns}\n"
+            f"   Try: drills 1-3 cold. Then check the answer key."
+        )
+    elif minutes <= 30:
+        steps.append(
+            f"1. Concept (10 min)\n"
+            f"   Open: {rel_concept}\n"
+            f"   Read: the CONCEPT and KEY POINTS blocks at the top."
+        )
+        steps.append(
+            f"2. Drill (5 min)\n"
+            f"   Open: {rel_patterns}\n"
+            f"   Try: drills 3-5 cold. Then check the answer key."
+        )
+        steps.append(
+            f"3. Verify (10 min)\n"
+            f"   Run: ./scripts/journey quiz {week} --n 3"
+        )
+    elif minutes <= 60:
+        steps.append(
+            f"1. Concept (10 min)\n"
+            f"   Open: {rel_concept}\n"
+            f"   Read: the CONCEPT and KEY POINTS blocks at the top."
+        )
+        steps.append(
+            f"2. Drill (5 min)\n"
+            f"   Open: {rel_patterns}\n"
+            f"   Try: drills 3-5 cold. Then check the answer key."
+        )
+        steps.append(
+            f"3. Implement (10 min)\n"
+            f"   Open: {rel_challenges}\n"
+            f"   Code: Challenge 1 from scratch in {workbook_dir}\n"
+            f"   Hint: ./scripts/journey new-attempt <topic>"
+        )
+        steps.append(
+            f"4. Verify (5 min)\n"
+            f"   Run: ./scripts/journey verify <topic> {workbook_dir}<your-file>.py"
+        )
+        steps.append(
+            f"5. Quiz (15 min)\n"
+            f"   Run: ./scripts/journey quiz {week}"
+        )
+    else:
+        # weekend — capstone or full week sprint
+        steps.append(
+            f"1. Capstone block (60 min)\n"
+            f"   Open: capstones/  (pick the capstone for this phase)\n"
+            f"   Implement one milestone end-to-end."
+        )
+        steps.append(
+            f"2. Concept + drill (30 min)\n"
+            f"   Open: {rel_concept} and {rel_patterns}\n"
+            f"   Read the concept, then run cold through every drill."
+        )
+        steps.append(
+            f"3. Implement (45 min)\n"
+            f"   Open: {rel_challenges}\n"
+            f"   Tackle Challenges 1 and 2 in {workbook_dir}"
+        )
+        steps.append(
+            f"4. Quiz (15 min)\n"
+            f"   Run: ./scripts/journey quiz {week}"
+        )
+        steps.append(
+            f"5. Reflect (15 min)\n"
+            f"   Run: ./scripts/journey reflect"
+        )
+    if due_count > 0:
+        steps.append(
+            f"Bonus: {due_count} skill(s) due for review.\n"
+            f"   Run: ./scripts/journey review"
+        )
+    return steps
+
+
+def cmd_next(args: argparse.Namespace) -> int:
+    progress = load_progress()
+    config = load_config()
+    minutes_str = getattr(args, "time", None) or config.get("time_per_session", "30m")
+    minutes = _parse_time(minutes_str)
+
+    # --skip: advance current_week pointer without doing the session.
+    if getattr(args, "skip", False):
+        cur = progress.get("current_week", 1)
+        if config.get("soft_gate_enabled", True) and not getattr(args, "force", False):
+            rate = _current_week_mastery_rate(progress, cur)
+            if rate < 80:
+                print(
+                    f"Soft gate: Week {cur} mastery is {rate:.0f}% (< 80%).\n"
+                    f"Run `./scripts/journey quiz {cur}` first, or use --force to override."
+                )
+                return 1
+        nxt = min(cur + 1, TOTAL_WEEKS)
+        progress["current_week"] = nxt
+        save_progress(progress)
+        print(f"Advanced pointer from Week {cur} → Week {nxt}.")
+        return 0
+
+    # 1. No progress at all → start onboarding
+    if not progress.get("weeks") and not progress.get("history"):
+        if not CONFIG_FILE.exists():
+            print("Welcome! Looks like this is your first session.")
+            print("Run: ./scripts/journey start")
+            return 0
+
+    current_week = progress.get("current_week", 1)
+    due = collect_due_skills(progress)
+    due_count = len(due)
+    rate = _current_week_mastery_rate(progress, current_week)
+
+    # Decision: which kind of session?
+    decision: str
+    target_week = current_week
+
+    # If current week never quizzed → suggest quiz session
+    rec = progress.get("weeks", {}).get(str(current_week))
+    if not rec or rate < 80:
+        decision = "mastery_quiz" if rec else "first_pass"
+    elif due_count > 0 and minutes >= 15:
+        decision = "review"
+    else:
+        # Advance to next week with soft gate
+        target_week = min(current_week + 1, TOTAL_WEEKS)
+        decision = "advance"
+        # Soft mastery gate
+        if (
+            config.get("soft_gate_enabled", True)
+            and not getattr(args, "force", False)
+            and rate < 80
+        ):
+            print(
+                f"Warning: Week {current_week} mastery is {rate:.0f}% (< 80%).\n"
+                f"Recommend running `./scripts/journey quiz {current_week}` "
+                f"before moving to Week {target_week}.\n"
+                f"Pass --force to skip this gate.\n"
+            )
+            target_week = current_week
+            decision = "mastery_quiz"
+
+    # ----- Header -----
+    today = _dt.date.today()
+    day_idx = today.toordinal() % 7 + 1
+    header = (
+        f"Next session — Week {target_week}, Day {day_idx} (~{minutes} min)"
+    )
+    print(header)
+    print()
+
+    # ----- Body by decision -----
+    if decision == "review" and due:
+        print(f"You have {due_count} skill(s) due for review (FSRS).")
+        print()
+        print(f"1. Review session (~{minutes} min)")
+        print(f"   Run: ./scripts/journey review --n {min(due_count, max(3, minutes // 3))}")
+        print()
+        # Show top 3 due skills
+        print("   Top due skills:")
+        for sk in due[:3]:
+            wk = sk.get("_week", "?")
+            sid = sk.get("id", "?")
+            print(f"     - Week {wk}: {sid}")
+    elif decision == "mastery_quiz":
+        print(
+            f"Current Week {target_week} mastery: {rate:.0f}% "
+            f"(need >= 80% to advance)."
+        )
+        print()
+        steps = _build_session_steps(target_week, minutes, due_count)
+        for s in steps:
+            print(s)
+            print()
+        print(f"   Then: ./scripts/journey quiz {target_week}")
+    else:
+        steps = _build_session_steps(target_week, minutes, due_count)
+        for s in steps:
+            print(s)
+            print()
+
+    print(
+        "Or skip with: ./scripts/journey next --skip "
+        "(advances pointer without doing the session)"
+    )
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# `verify` — run user code against fixture cases
+# ---------------------------------------------------------------------------
+
+def cmd_verify(args: argparse.Namespace) -> int:
+    topic = args.topic
+    user_file = Path(args.file).expanduser().resolve()
+
+    resolved = resolve_topic_fixture(topic)
+    if not resolved:
+        topics = available_topics()
+        print(f"error: topic '{topic}' has no fixture.")
+        if topics:
+            print("Available topics:")
+            for t in topics:
+                print(f"  - {t}")
+            print()
+            print("You can also use aliases like: kadane, dutch_flag, two_sum, etc.")
+        return 2
+
+    fixture_id, fixture_path = resolved
+
+    if not user_file.is_file():
+        print(f"error: user file not found: {user_file}")
+        return 2
+
+    try:
+        fixture = json.loads(fixture_path.read_text())
+    except Exception as e:
+        print(f"error: could not parse fixture {fixture_path}: {e}")
+        return 2
+
+    func_name = fixture.get("function")
+    cases = fixture.get("cases", [])
+    if not func_name or not cases:
+        print(f"error: fixture {fixture_path.name} missing function/cases.")
+        return 2
+
+    # Dynamically import the user file as a module.
+    import importlib.util
+    mod_name = f"_journey_user_{user_file.stem}"
+    spec = importlib.util.spec_from_file_location(mod_name, str(user_file))
+    if spec is None or spec.loader is None:
+        print(f"error: could not load module from {user_file}")
+        return 2
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)  # type: ignore[union-attr]
+    except Exception as e:
+        print(f"error: importing {user_file.name} raised: {type(e).__name__}: {e}")
+        return 2
+
+    fn = getattr(module, func_name, None)
+    if fn is None or not callable(fn):
+        print(
+            f"error: {user_file.name} does not define a callable "
+            f"`{func_name}(...)`."
+        )
+        # Hint at what was found
+        names = [n for n in dir(module) if callable(getattr(module, n)) and not n.startswith("_")]
+        if names:
+            print(f"  Found callables: {', '.join(names[:10])}")
+        return 2
+
+    rel_fixture = fixture_path.relative_to(REPO_ROOT) if fixture_path.is_relative_to(REPO_ROOT) else fixture_path
+    print(
+        f"Verifying {topic} (your code) against {rel_fixture} ({len(cases)} cases)"
+    )
+
+    passed = 0
+    fails: list[tuple[str, object, object]] = []
+    for case in cases:
+        name = case.get("name", "?")
+        case_input = case.get("input", [])
+        expected = case.get("expected")
+        try:
+            got = fn(*case_input)
+        except Exception as e:
+            print(f"FAIL {name}")
+            print(f"  input:    {case_input}")
+            print(f"  expected: {expected}")
+            print(f"  got:      raised {type(e).__name__}: {e}")
+            fails.append((name, expected, f"<raised {type(e).__name__}>"))
+            continue
+        if got == expected:
+            print(f"PASS {name}")
+            passed += 1
+        else:
+            print(f"FAIL {name}")
+            print(f"  input:    {case_input}")
+            print(f"  expected: {expected}")
+            print(f"  got:      {got}")
+            fails.append((name, expected, got))
+
+    total = len(cases)
+    print()
+    print(f"TOTAL: {passed}/{total} passed")
+    ref_py = REPO_ROOT / "tests" / "refs" / f"{fixture_id}.py"
+    if ref_py.is_file():
+        rel_ref = ref_py.relative_to(REPO_ROOT)
+        print(f"Diff against canonical: {rel_ref}")
+    return 0 if passed == total else 1
+
+
+# ---------------------------------------------------------------------------
+# `new-attempt` — generate a workbook stub for a topic
+# ---------------------------------------------------------------------------
+
+LANG_EXT = {"python": "py", "java": "java", "cpp": "cpp", "rust": "rs"}
+
+
+def _stub_for_python(topic: str, fixture: dict, week: int) -> str:
+    func = fixture.get("function", topic)
+    cases = fixture.get("cases", []) or []
+    today = _dt.date.today().isoformat()
+    sample = cases[0] if cases else {"input": [], "expected": None}
+    sample_input = sample.get("input", [])
+    sample_expected = sample.get("expected")
+    return (
+        f"# Topic: {topic}\n"
+        f"# Week: {week}\n"
+        f"# Date: {today}\n"
+        f"# Generated by `./scripts/journey new-attempt {topic}`.\n"
+        f"#\n"
+        f"# Implement the function below so that `verify` passes:\n"
+        f"#   ./scripts/journey verify {topic} <path-to-this-file>\n"
+        f"\n"
+        f"def {func}(*args):\n"
+        f"    # WRITE YOUR CODE HERE\n"
+        f"    # ----------------------------------------------------------\n"
+        f"    # Tip: don't peek at tests/refs/{topic}.py until you've tried.\n"
+        f"    # ----------------------------------------------------------\n"
+        f"    raise NotImplementedError(\"{func} is not implemented yet\")\n"
+        f"\n"
+        f"\n"
+        f"if __name__ == \"__main__\":\n"
+        f"    # Sample input from the fixture; expected: {sample_expected!r}\n"
+        f"    sample_input = {sample_input!r}\n"
+        f"    print({func}(*sample_input))\n"
+    )
+
+
+def _stub_for_other(topic: str, fixture: dict, week: int, lang: str) -> str:
+    func = fixture.get("function", topic)
+    today = _dt.date.today().isoformat()
+    comment = "//"
+    return (
+        f"{comment} Topic: {topic}\n"
+        f"{comment} Week: {week}\n"
+        f"{comment} Date: {today}\n"
+        f"{comment} Language: {lang}\n"
+        f"{comment} Function to implement: {func}\n"
+        f"{comment} WRITE YOUR CODE HERE\n"
+    )
+
+
+def cmd_new_attempt(args: argparse.Namespace) -> int:
+    config = load_config()
+    lang = (getattr(args, "lang", None) or config.get("language") or "python").lower()
+    ext = LANG_EXT.get(lang, "py")
+
+    topic = args.topic
+    resolved = resolve_topic_fixture(topic)
+    if not resolved:
+        topics = available_topics()
+        print(f"error: topic '{topic}' has no fixture.")
+        if topics:
+            print("Available topics:")
+            for t in topics:
+                print(f"  - {t}")
+        return 2
+    fixture_id, fixture_path = resolved
+    try:
+        fixture = json.loads(fixture_path.read_text())
+    except Exception as e:
+        print(f"error: could not parse fixture: {e}")
+        return 2
+
+    progress = load_progress()
+    week = progress.get("current_week", 1)
+
+    attempts_dir = REPO_ROOT / "workbook" / f"week_{week:02d}" / "attempts"
+    attempts_dir.mkdir(parents=True, exist_ok=True)
+
+    today = _dt.date.today().isoformat()
+    base = f"{topic}__{today}"
+    target = attempts_dir / f"{base}.{ext}"
+    # Don't overwrite — bump a counter
+    counter = 2
+    while target.exists():
+        target = attempts_dir / f"{base}-{counter}.{ext}"
+        counter += 1
+
+    if lang == "python":
+        content = _stub_for_python(topic, fixture, week)
+    else:
+        content = _stub_for_other(topic, fixture, week, lang)
+    target.write_text(content)
+    rel = target.relative_to(REPO_ROOT) if target.is_relative_to(REPO_ROOT) else target
+    print(f"Created: {rel}")
+    print(f"  Function to implement: {fixture.get('function')}")
+    print(f"  Verify with: ./scripts/journey verify {topic} {rel}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# `reflect` — append a journal entry to the workbook
+# ---------------------------------------------------------------------------
+
+def _parse_reflection_prompts(week: int) -> list[str]:
+    """Pull the bullet list under the 'Reflection prompts' section of the
+    week's README. Returns up to 4 prompts."""
+    readme = REPO_ROOT / f"Week {week}" / "README.md"
+    if not readme.is_file():
+        return []
+    lines = readme.read_text(encoding="utf-8").splitlines()
+    in_section = False
+    prompts: list[str] = []
+    for ln in lines:
+        if re.match(r"^#{1,6}\s+Reflection\s+prompts?\b", ln, re.IGNORECASE):
+            in_section = True
+            continue
+        if in_section:
+            if re.match(r"^#{1,6}\s+", ln):  # next heading ends the section
+                break
+            m = re.match(r"^\s*[-*]\s+(.+)$", ln)
+            if m:
+                prompts.append(m.group(1).strip())
+    return prompts[:4]
+
+
+_FALLBACK_REFLECTION_PROMPTS = [
+    "What was the hardest concept this week, and what made it hard?",
+    "Which pattern did you fail to recognize first, and what would have tipped you off?",
+    "If you had to teach this week's flagship algorithm in one sentence, what would you say?",
+    "What problem would you want to revisit in 3 weeks to test retention?",
+]
+
+
+def cmd_reflect(args: argparse.Namespace) -> int:
+    progress = load_progress()
+    week = getattr(args, "week", None) or progress.get("current_week", 1)
+    journal_dir = REPO_ROOT / "workbook" / f"week_{week:02d}"
+    journal_dir.mkdir(parents=True, exist_ok=True)
+    journal = journal_dir / "journal.md"
+
+    prompts = _parse_reflection_prompts(week)
+    if not prompts:
+        prompts = _FALLBACK_REFLECTION_PROMPTS
+
+    today = _dt.date.today().isoformat()
+    lines: list[str] = []
+    if not journal.exists():
+        lines.append(f"# Week {week} — Journal")
+        lines.append("")
+        lines.append(
+            "Append a dated entry every session. Source prompts: "
+            f"`Week {week}/README.md` Reflection prompts section."
+        )
+        lines.append("")
+
+    lines.append(f"## {today}")
+    lines.append("")
+    for p in prompts:
+        lines.append(f"**{p}**")
+        lines.append("")
+        lines.append("_(your thoughts here)_")
+        lines.append("")
+    lines.append("---")
+    lines.append("")
+    block = "\n".join(lines)
+
+    with journal.open("a", encoding="utf-8") as fh:
+        fh.write(block)
+
+    rel = journal.relative_to(REPO_ROOT) if journal.is_relative_to(REPO_ROOT) else journal
+    print(f"Appended entry to: {rel}")
+    print()
+    print("Template appended:")
+    print("-" * 60)
+    print(block)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# `start` — interactive onboarding
+# ---------------------------------------------------------------------------
+
+def _ask(prompt: str, default: str, choices: list[str] | None = None) -> str:
+    if NON_INTERACTIVE:
+        return default
+    try:
+        raw = input(prompt).strip()
+    except EOFError:
+        return default
+    if not raw:
+        return default
+    if choices and raw.lower() not in choices:
+        print(f"  (invalid — using default: {default})")
+        return default
+    return raw.lower()
+
+
+def cmd_start(_args: argparse.Namespace) -> int:
+    print("DSA Journey — onboarding (about 2 minutes)")
+    print("=" * 50)
+    print()
+
+    language = _ask(
+        "Primary language? (python / java / cpp / rust) [python]: ",
+        "python",
+        ["python", "java", "cpp", "rust"],
+    )
+    time_per_session = _ask(
+        "Time per session? (15m / 30m / 1h) [30m]: ",
+        "30m",
+        ["15m", "30m", "1h"],
+    )
+    goal = _ask(
+        "Goal? (interview / curriculum / exploration) [curriculum]: ",
+        "curriculum",
+        ["interview", "curriculum", "exploration"],
+    )
+    skip_diag = _ask(
+        "Skip the diagnostic? (y/N) [N]: ",
+        "n",
+        ["y", "n", "yes", "no"],
+    )
+
+    cfg = dict(DEFAULT_CONFIG)
+    cfg.update({
+        "language": language,
+        "time_per_session": time_per_session,
+        "goal": goal,
+        "soft_gate_enabled": True,
+    })
+    save_config(cfg)
+
+    # Ensure progress.json exists with a sensible current_week
+    progress = load_progress()
+    if "current_week" not in progress:
+        progress["current_week"] = 1
+        save_progress(progress)
+
+    print()
+    print(f"Saved config: {CONFIG_FILE}")
+    if skip_diag.startswith("n"):
+        diag = REPO_ROOT / "docs" / "diagnostic.md"
+        if diag.is_file():
+            rel = diag.relative_to(REPO_ROOT)
+            print(f"Recommended: open {rel} for the 15-question placement test.")
+        # Also surface progress at a glance
+        print()
+        try:
+            cmd_progress(argparse.Namespace(html=False, open=False))
+        except Exception:
+            pass
+    print()
+    print("Setup complete. Run `./scripts/journey next` to get your first session.")
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # Argparse
 # ---------------------------------------------------------------------------
 
 def build_parser() -> argparse.ArgumentParser:
+
     p = argparse.ArgumentParser(prog="journey", description="DSA-journey mastery CLI.")
     sub = p.add_subparsers(dest="cmd")
 
@@ -1370,6 +2087,71 @@ def build_parser() -> argparse.ArgumentParser:
         help="Render as Markdown (suitable for piping into emails / issues)",
     )
     dly.set_defaults(func=cmd_daily)
+
+    # `next` — pick one concrete session
+    nx = sub.add_parser(
+        "next",
+        help="Pick ONE concrete next action based on progress + due skills + time.",
+    )
+    nx.add_argument(
+        "--time",
+        default=None,
+        help="Time budget: 15m | 30m | 1h | weekend (default: from config or 30m)",
+    )
+    nx.add_argument(
+        "--force",
+        action="store_true",
+        help="Override the soft mastery gate (advance even if current week <80%).",
+    )
+    nx.add_argument(
+        "--skip",
+        action="store_true",
+        help="Advance current_week pointer without running a session.",
+    )
+    nx.set_defaults(func=cmd_next)
+
+    # `verify` — run user code against fixture
+    vr = sub.add_parser(
+        "verify",
+        help="Run your code against the fixture cases for a topic.",
+    )
+    vr.add_argument("topic", help="Topic name (e.g. kadane, two_sum, dijkstra)")
+    vr.add_argument("file", help="Path to your implementation file.")
+    vr.set_defaults(func=cmd_verify)
+
+    # `new-attempt` — scaffold a workbook stub
+    na = sub.add_parser(
+        "new-attempt",
+        help="Create a workbook stub for a topic (uses current_week).",
+    )
+    na.add_argument("topic", help="Topic name (e.g. kadane, two_sum).")
+    na.add_argument(
+        "--lang",
+        default=None,
+        choices=["python", "java", "cpp", "rust"],
+        help="Override config language for this stub.",
+    )
+    na.set_defaults(func=cmd_new_attempt)
+
+    # `reflect` — append journal entry
+    rf = sub.add_parser(
+        "reflect",
+        help="Append a journal entry with reflection prompts to workbook/week_NN/journal.md.",
+    )
+    rf.add_argument(
+        "--week",
+        type=int,
+        default=None,
+        help="Override current_week.",
+    )
+    rf.set_defaults(func=cmd_reflect)
+
+    # `start` — onboarding
+    st = sub.add_parser(
+        "start",
+        help="Interactive onboarding — sets language, time, goal, soft_gate.",
+    )
+    st.set_defaults(func=cmd_start)
 
     return p
 

--- a/scripts/quality_check.py
+++ b/scripts/quality_check.py
@@ -483,10 +483,22 @@ def run_check_challenges() -> tuple[int, list[Issue]]:
 # ---------------------------------------------------------------------------
 
 README_REQUIRED = [
-    "## Tradeoff Matrix",
-    "## Anti-patterns to avoid",
-    "## Reflection prompts",
+    # Each entry is a tuple of acceptable forms. The header check passes if
+    # ANY of the listed forms appears in the README. We accept both the
+    # original "## Tradeoff Matrix" form and the post-restructure
+    # "## Reference: tradeoff matrix" form (case-insensitive on the
+    # second form, since the restructure lowercased the section names
+    # when nesting them as collapsible reference blocks).
+    ("## Tradeoff Matrix", "## Reference: tradeoff matrix"),
+    ("## Anti-patterns to avoid", "## Reference: anti-patterns to avoid"),
+    ("## Reflection prompts",),
 ]
+
+
+def _readme_has_section(text: str, accepted_forms: tuple[str, ...]) -> bool:
+    """Case-insensitive presence check for any of the accepted forms."""
+    lowered = text.lower()
+    return any(form.lower() in lowered for form in accepted_forms)
 
 
 def run_check_readmes() -> tuple[int, list[Issue]]:
@@ -499,7 +511,7 @@ def run_check_readmes() -> tuple[int, list[Issue]]:
             continue
         total += 1
         text = read_text_safely(f) or ""
-        missing = [h for h in README_REQUIRED if h not in text]
+        missing = [forms[0] for forms in README_REQUIRED if not _readme_has_section(text, forms)]
         # Topic-index table: a markdown table whose header row includes the
         # language column names. We look for a header row containing at least
         # three of {Java, Python, C++, Rust, Web}.

--- a/workbook/README.md
+++ b/workbook/README.md
@@ -1,0 +1,33 @@
+# Workbook — YOUR space
+
+This directory is where you write code while learning. It's intentionally gitignored — your in-progress attempts don't belong in the upstream repo.
+
+## How it gets populated
+
+The `./scripts/journey` CLI writes here:
+
+- `./scripts/journey new-attempt kadane` → creates `workbook/week_06/attempts/kadane__2026-05-21.py` with a function stub for you to fill in.
+- `./scripts/journey reflect` → appends today's reflection prompts to `workbook/week_06/journal.md`.
+- `./scripts/journey verify kadane workbook/week_06/attempts/kadane__2026-05-21.py` → runs YOUR code against the topic's fixtures.
+
+## Layout
+
+```
+workbook/
+├── README.md           # this file (NOT gitignored)
+├── week_01/
+│   ├── attempts/       # one file per topic per attempt-date
+│   ├── journal.md      # your reflection entries
+│   └── notes.md        # your freeform notes
+├── week_02/
+├── ...
+└── week_30/
+```
+
+## The point
+
+Reading the canonical solutions teaches you what good code looks like. Writing your OWN code first, then comparing, teaches you DSA. The repo gives you the canonical for reference; the workbook gives you a place to fail safely before peeking.
+
+## Sharing
+
+By default, nothing in `workbook/` is tracked by git. If you want to share a finished capstone or a clever solution, copy it to `showcase/submissions/<your-handle>-<topic>.md` and open a PR. See `showcase/README.md` for the format.


### PR DESCRIPTION
## Summary

Reshape the repo from a *reference library* into a *guided course*. Until now it had amazing infrastructure (30 weeks × 4 languages × tests × quality lint × FSRS × viz × capstones × certification…) but a learner faced 9 entry points per week and had to figure out what to do on their own. This PR makes the actual learning experience real.

## The 5 structural changes

### 1. `./scripts/journey next` — the "what do I do RIGHT NOW" engine
The single most important new command. Picks ONE concrete next action based on (a) where you left off, (b) FSRS-due skills, (c) available time. Output is a session plan, not a menu:
```
Next session — Week 6, Day 3 (~30 min)
  1. Concept (10 min): open Week 6/python/<canonical>.py
  2. Drill (5 min): try patterns.md drills 3-5
  3. Implement (10 min): code Challenge 1 in workbook/
  4. Verify (5 min): ./scripts/journey verify <topic> workbook/<file>
```
Soft mastery gate warns when skipping ahead with <80% on current week (`--force` overrides). Time scaling: `--time 15m | 30m | 1h | weekend`.

### 2. `./scripts/journey verify <topic> <file>` — check YOUR code
The most empowering single command. Dynamically imports the learner's Python file, runs it against the topic's fixture cases, prints PASS/FAIL with exact input/expected/got diffs. **Verified**: a deliberately broken Kadane (returns sum instead of max subarray) correctly fails 3/6 cases showing the inputs that broke it.

### 3. Per-week README — "Today's session" linear path at top
All 30 `Week N/README.md` files restructured. First thing a learner sees is a 5-step session plan (≈45 min for algorithms, ≈30 min for syntax-only Weeks 1-3). Existing dense reference material (topic-index table, tradeoff matrix, anti-patterns, how-to-run) preserved verbatim but collapsed in `<details>` blocks below.

### 4. `workbook/` — personal workspace inside the repo
New top-level `workbook/` directory (gitignored except its README). The journey CLI writes here:
- `./journey new-attempt kadane` → `workbook/week_06/attempts/kadane__YYYY-MM-DD.py` with function signature pre-filled
- `./journey reflect` → appends today's prompts to `workbook/week_06/journal.md`
- `./journey verify` knows to look in `workbook/` automatically

The repo went from "consume" to "use."

### 5. Python as primary language
Per-week READMEs route learners to `python/` by default. Other languages remain in expandable "compare implementations" reference blocks. The 1:1 parity stays as a feature for polyglot learners but stops being the default presentation.

## 5 supporting changes

| # | Item |
|---|------|
| 6 | Inline viz embeds + mock-interview + capstone cross-links in per-week READMEs |
| 7 | Soft mastery gates in `journey next` (override with `--force`) |
| 8 | Mock interviews mapped to specific weeks; capstones surfaced at phase boundaries (weeks 5/10/15/20/25/30) |
| 9 | `./scripts/journey start` 2-min interactive onboarding (lang / time / goal → `~/.journey/config.json`) |
| 10 | Time-scaled sessions: `--time 15m / 30m / 1h / weekend` |

## Documentation

- **`docs/JOURNEY_CLI.md`** (new): full reference for every subcommand with examples + workflows + config schema
- **`workbook/README.md`** (new): explains the personal-workspace flow
- `README.md`: "Start Here" rewritten around `journey start` + `journey next`; new "How the journey CLI works" reference table; new "Your workspace: workbook/" subsection
- `INDEX.md`: Tools section reorganized around the daily learning loop
- `CONTRIBUTING.md`: added Workbook subsection
- `QUICKSTART.md`: optional `journey start && journey next` shortcut
- `docs/MASTERY.md`: appended "What's next?" section
- `scripts/build_all.sh`: added `next` passthrough

## Quality lint update

Lint check for `## Tradeoff Matrix` / `## Anti-patterns to avoid` now accepts the restructured `## Reference: tradeoff matrix` / `## Reference: anti-patterns to avoid` forms too (case-insensitive). All 30 weeks pass.

## Verification

```
$ for lang in python cpp rust java; do
    python tests/harness/harness.py --all --lang "$lang" 2>&1 | grep ^TOTAL: | tail -1
  done
TOTAL: 120 passed, 0 failed across 25 fixtures      # python
TOTAL: 120 passed, 0 failed across 25 fixtures      # cpp
TOTAL: 120 passed, 0 failed across 25 fixtures      # rust
TOTAL: 120 passed, 0 failed across 25 fixtures      # java

$ python scripts/quality_check.py --quiet && echo OK
OK

$ bash scripts/prepare_site.sh && mkdocs build --strict
INFO    -  Documentation built in 3.04 seconds

# Bad Kadane catches:
$ cat > /tmp/bad.py <<EOF
def maxSubarraySum(arr): return sum(arr)
EOF
$ ./scripts/journey verify kadane /tmp/bad.py
FAIL stress_alternating
  input:    [[8, -19, 5, -4, 20, 5, -25, 10, 10, ...]]
  expected: 240
  got:      164
TOTAL: 3/6 passed
Diff against canonical: tests/refs/kadane_max_subarray.py
```

## Test plan

- [ ] CI: all 7+ jobs go green
- [ ] `./scripts/journey start` (or `JOURNEY_NON_INTERACTIVE=1 ./scripts/journey start`) writes `~/.journey/config.json`
- [ ] `./scripts/journey next` returns a sensible session plan
- [ ] `./scripts/journey new-attempt kadane` creates a stub in `workbook/`
- [ ] Write a correct Kadane in the stub, `./scripts/journey verify kadane <file>` → 6/6 pass
- [ ] Write a broken Kadane, `journey verify` → catches the failing case with diff
- [ ] Open `Week 6/README.md` and confirm "Today's session" is the first section
- [ ] mkdocs site still builds and deploys

Net effect: a learner who clones the repo can now run `./scripts/journey start && ./scripts/journey next` and be doing productive learning work in 60 seconds with zero documentation reading required.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KhmTsSLVQJAHwRzJ2kFF8R)_